### PR TITLE
harden rate limit IP handling, fix FP aggregation, apply triage escal…

### DIFF
--- a/internal/evaluate/evaluate.go
+++ b/internal/evaluate/evaluate.go
@@ -214,6 +214,22 @@ func (e *Evaluator) incorporateTriageResults(mode config.EvaluationMode, critica
 		return baseAction, baseOverridable
 	}
 
+	// Base action is allow in enforce mode. Triage may only escalate:
+	// - block if any high-confidence block verdict
+	// - otherwise log if any medium-confidence investigate verdict
+	hasInvestigate := false
+	for _, tr := range triageResults {
+		if strings.EqualFold(tr.Verdict, "block") && tr.Confidence >= 0.90 {
+			return models.ActionBlock, true
+		}
+		if strings.EqualFold(tr.Verdict, "investigate") && tr.Confidence >= 0.70 {
+			hasInvestigate = true
+		}
+	}
+	if hasInvestigate {
+		return models.ActionLog, false
+	}
+
 	return baseAction, baseOverridable
 }
 

--- a/internal/evaluate/evaluate_test.go
+++ b/internal/evaluate/evaluate_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/agentshield-ai/agentshield/internal/config"
 	"github.com/agentshield-ai/agentshield/internal/engine"
 	"github.com/agentshield-ai/agentshield/internal/models"
+	"github.com/agentshield-ai/agentshield/internal/triage"
 )
 
 // mockEngine implements a simple mock for testing
@@ -204,6 +205,69 @@ func TestEvaluate(t *testing.T) {
 				if !alert.Matched {
 					t.Errorf("Alert should only contain matched rules, got unmatched rule: %s", alert.RuleID)
 				}
+			}
+		})
+	}
+}
+
+func TestIncorporateTriageResultsEscalationPolicy(t *testing.T) {
+	evaluator := &Evaluator{}
+
+	tests := []struct {
+		name          string
+		mode          config.EvaluationMode
+		criticalCount int
+		highCount     int
+		triage        []triage.TriageResult
+		wantAction    models.Action
+		wantOverride  bool
+	}{
+		{
+			name:          "base block never downgraded",
+			mode:          config.ModeEnforce,
+			criticalCount: 1,
+			triage: []triage.TriageResult{{Verdict: "allow", Confidence: 0.99}},
+			wantAction:   models.ActionBlock,
+			wantOverride: true,
+		},
+		{
+			name:       "allow escalates to block on high confidence block verdict",
+			mode:       config.ModeEnforce,
+			triage:     []triage.TriageResult{{Verdict: "block", Confidence: 0.90}},
+			wantAction: models.ActionBlock,
+			wantOverride: true,
+		},
+		{
+			name:       "allow escalates to log on investigate threshold",
+			mode:       config.ModeEnforce,
+			triage:     []triage.TriageResult{{Verdict: "investigate", Confidence: 0.70}},
+			wantAction: models.ActionLog,
+			wantOverride: false,
+		},
+		{
+			name:       "below thresholds remains allow",
+			mode:       config.ModeEnforce,
+			triage:     []triage.TriageResult{{Verdict: "block", Confidence: 0.89}, {Verdict: "investigate", Confidence: 0.69}},
+			wantAction: models.ActionAllow,
+			wantOverride: false,
+		},
+		{
+			name:       "audit mode unaffected",
+			mode:       config.ModeAudit,
+			triage:     []triage.TriageResult{{Verdict: "block", Confidence: 0.99}},
+			wantAction: models.ActionLog,
+			wantOverride: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotAction, gotOverride := evaluator.incorporateTriageResults(tt.mode, tt.criticalCount, tt.highCount, tt.triage)
+			if gotAction != tt.wantAction {
+				t.Fatalf("action=%s want=%s", gotAction, tt.wantAction)
+			}
+			if gotOverride != tt.wantOverride {
+				t.Fatalf("overridable=%t want=%t", gotOverride, tt.wantOverride)
 			}
 		})
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -295,14 +296,11 @@ func (rl *ipRateLimiter) cleanup() {
 func rateLimitMiddleware(limiter *ipRateLimiter) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// SECURITY: Do not trust user-supplied forwarding headers here.
+			// middleware.RealIP normalizes RemoteAddr based on trusted proxy chain.
 			ip := r.RemoteAddr
-			// Use X-Real-IP if set (behind reverse proxy)
-			if realIP := r.Header.Get("X-Real-Ip"); realIP != "" {
-				ip = realIP
-			}
-			// Strip port
-			if idx := strings.LastIndex(ip, ":"); idx > 0 {
-				ip = ip[:idx]
+			if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+				ip = host
 			}
 
 			if !limiter.allow(ip) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -622,6 +622,35 @@ func TestNewServerWithoutAuth(t *testing.T) {
 	}
 }
 
+func TestRateLimitMiddlewareIgnoresSpoofedXRealIP(t *testing.T) {
+	limiter := newIPRateLimiter(1, time.Minute)
+	mw := rateLimitMiddleware(limiter)
+
+	h := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// First request from IP A should pass.
+	req1 := httptest.NewRequest(http.MethodGet, "/", nil)
+	req1.RemoteAddr = "10.0.0.1:1234"
+	req1.Header.Set("X-Real-Ip", "198.51.100.9")
+	rec1 := httptest.NewRecorder()
+	h.ServeHTTP(rec1, req1)
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("first request expected 200, got %d", rec1.Code)
+	}
+
+	// Second request from same remote should be limited even if spoofed header changes.
+	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	req2.RemoteAddr = "10.0.0.1:5678"
+	req2.Header.Set("X-Real-Ip", "203.0.113.77")
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusTooManyRequests {
+		t.Fatalf("second request expected 429, got %d", rec2.Code)
+	}
+}
+
 func TestRequestLogger(t *testing.T) {
 	testStore, err := store.NewStore(":memory:")
 	if err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -391,13 +391,21 @@ func (s *Store) GetRuleFPRate(ruleName string) (float64, error) {
 // GetRulesWithHighFPRate returns rules with false positive rate above threshold
 func (s *Store) GetRulesWithHighFPRate(threshold float64, minAlerts int) ([]string, error) {
 	query := `
-		SELECT a.rule_name, 
-			   COUNT(*) as total_alerts,
-			   COUNT(CASE WHEN f.feedback_type = 'false_positive' THEN 1 END) as fp_count
-		FROM alerts a
-		LEFT JOIN feedback f ON a.rule_name = f.rule_name
-		GROUP BY a.rule_name
-		HAVING total_alerts >= ?
+		WITH alert_counts AS (
+			SELECT rule_name, COUNT(*) AS total_alerts
+			FROM alerts
+			GROUP BY rule_name
+		),
+		fp_counts AS (
+			SELECT rule_name, COUNT(*) AS fp_count
+			FROM feedback
+			WHERE feedback_type = 'false_positive'
+			GROUP BY rule_name
+		)
+		SELECT a.rule_name, a.total_alerts, COALESCE(f.fp_count, 0) AS fp_count
+		FROM alert_counts a
+		LEFT JOIN fp_counts f ON a.rule_name = f.rule_name
+		WHERE a.total_alerts >= ?
 		ORDER BY a.rule_name
 	`
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -543,6 +543,46 @@ func TestGetRulesWithHighFPRate(t *testing.T) {
 	}
 }
 
+func TestGetRulesWithHighFPRateNoJoinMultiplication(t *testing.T) {
+	store, err := NewStore(":memory:")
+	if err != nil {
+		t.Fatalf("creating test store: %v", err)
+	}
+	defer store.Close()
+
+	// 2 alerts for same rule
+	alerts := []*Alert{
+		{RuleName: "ruleA", Severity: "high", ActionTaken: "block", Timestamp: time.Now(), EventID: "a1"},
+		{RuleName: "ruleA", Severity: "high", ActionTaken: "block", Timestamp: time.Now(), EventID: "a2"},
+	}
+	for _, a := range alerts {
+		if err := store.InsertAlert(a); err != nil {
+			t.Fatalf("insert alert: %v", err)
+		}
+	}
+
+	// 3 false-positive feedback rows for same rule (can exceed alert count; should not multiply total alerts)
+	for i := range alerts {
+		id := alerts[i].ID
+		if err := store.InsertFeedback(alerts[i].EventID, &id, "false_positive", ""); err != nil {
+			t.Fatalf("insert feedback: %v", err)
+		}
+	}
+	id := alerts[0].ID
+	if err := store.InsertFeedback("a1", &id, "false_positive", "extra"); err != nil {
+		t.Fatalf("insert extra feedback: %v", err)
+	}
+
+	// threshold 1.1 should still include ruleA with correct math (3/2 = 1.5)
+	rules, err := store.GetRulesWithHighFPRate(1.1, 1)
+	if err != nil {
+		t.Fatalf("GetRulesWithHighFPRate failed: %v", err)
+	}
+	if len(rules) != 1 || rules[0] != "ruleA" {
+		t.Fatalf("expected [ruleA], got %#v", rules)
+	}
+}
+
 func TestGetStats(t *testing.T) {
 	store, err := NewStore(":memory:")
 	if err != nil {


### PR DESCRIPTION


*Summary*
This PR delivers a P0 hardening pack across server, store, and evaluator paths:

1) *Rate-limit hardening* (`internal/server/server.go`)
- Stop trusting `X-Real-Ip` directly in limiter path
- Derive client IP from `RemoteAddr` using `net.SplitHostPort` with fallback

2) *False-positive aggregation fix* (`internal/store/store.go`)
- Fix `GetRulesWithHighFPRate` query to avoid join multiplication
- Use CTE-based aggregate counts for true alert totals and FP totals

3) *Triage escalation policy wiring* (`internal/evaluate/evaluate.go`)
- Preserve non-downgradable block in enforce mode
- If base action is allow in enforce mode, escalate by triage:
- `block` if any triage verdict is `block` with confidence >= 0.90
- `log` if any triage verdict is `investigate` with confidence >= 0.70
- else keep base action

*Tests added*
- `TestRateLimitMiddlewareIgnoresSpoofedXRealIP` (`internal/server/server_test.go`)
- `TestGetRulesWithHighFPRateNoJoinMultiplication` (`internal/store/store_test.go`)
- `TestIncorporateTriageResultsEscalationPolicy` (`internal/evaluate/evaluate_test.go`)

*Validation*
- `go test ./...` passes

*Notes*
- Branch: `fix/p0-hardening-pack-1`
- Commit: `3b77aebe4cab7198e053bf228a1a97cba271812f`