### PR TITLE
chore(rules): consume sigma-ai as subtree with sync automation

### DIFF
--- a/.github/workflows/sigma-ai-sync-check.yml
+++ b/.github/workflows/sigma-ai-sync-check.yml
@@ -1,0 +1,21 @@
+name: Sigma-AI Subtree Sync Check
+
+on:
+  pull_request:
+    paths:
+      - 'rules/upstream/sigma-ai/**'
+      - 'scripts/check_sigma_ai_sync.sh'
+      - '.github/workflows/sigma-ai-sync-check.yml'
+  schedule:
+    - cron: '30 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  sync-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify vendored sigma-ai subtree matches upstream main
+        run: |
+          chmod +x scripts/check_sigma_ai_sync.sh
+          scripts/check_sigma_ai_sync.sh main

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ chmod +x ~/.claude-code/hooks/*
 ```
 
 ### 📊 Detection Rules ([`rules/`](rules/))
+AgentShield consumes engine-agnostic Sigma-AI rules from the upstream catalog (`agentshield-ai/sigma-ai`) vendored under [`rules/upstream/sigma-ai/`](rules/upstream/sigma-ai/).
+
 Community-maintained Sigma rules for AI agent threats:
 - **Prompt Injection**: Social engineering and manipulation detection
 - **Tool Poisoning**: Malicious tool usage patterns
@@ -172,7 +174,8 @@ git commit -m "feat: add custom threat detection"
 
 ## Community
 
-- **Rules Repository**: [sigma-rules](rules/) - Community threat patterns
+- **Canonical Rules Repository**: [sigma-ai](https://github.com/agentshield-ai/sigma-ai) - Engine-agnostic AI-agent Sigma rules
+- **Vendored Upstream Snapshot**: [`rules/upstream/sigma-ai/`](rules/upstream/sigma-ai/) - Imported into this engine repo via subtree
 - **Plugin Development**: [plugins/](plugins/) - Platform integrations
 - **Documentation**: [docs/](docs/) - Comprehensive guides
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,248 @@
+# AgentShield Sigma Rules
+
+A comprehensive collection of Sigma detection rules specifically designed for AI agent security monitoring and threat detection.
+
+## Overview
+
+This repository contains **36 Sigma rules** organized across **12 MITRE ATT&CK categories**, providing comprehensive coverage for AI agent threat detection. These rules cover various attack vectors against AI agents including prompt injection, tool poisoning, credential theft, data exfiltration, privilege escalation, and defense evasion techniques.
+
+The rules are designed for use with the [AgentShield detection engine](https://github.com/agentshield-ai/agentshield-engine) but are compatible with any Sigma-based detection system.
+
+## Rule Statistics
+
+- **Total Rules**: 36
+- **Categories**: 12 MITRE ATT&CK tactics  
+- **Format**: Standard Sigma YAML
+- **Maintenance**: Actively maintained with regular updates
+
+### Rules by Category
+
+| Category | Rule Count | Description |
+|----------|------------|-------------|
+| **Defense Evasion** | 8 | Memory poisoning, config manipulation, shell modification |
+| **Exfiltration** | 5 | DNS tunneling, HTTP exfil, steganography, network uploads |
+| **Privilege Escalation** | 4 | Container escape, IAM escalation, system file tampering |
+| **Credential Access** | 3 | SSH keys, cloud credentials, environment files |
+| **Execution** | 3 | Remote code execution, dangerous commands, session spawn |
+| **Persistence** | 3 | Backdoors, rule tampering, MCP manipulation |
+| **Prompt Injection** | 3 | Direct jailbreaks, indirect manipulation, tool outputs |
+| **Tool Poisoning** | 2 | MCP manipulation, skill tampering, rug pulls |
+| **Discovery** | 2 | Network reconnaissance, DNS enumeration |
+| **Collection** | 1 | Suspicious file operations to sensitive paths |
+| **Initial Access** | 1 | Untrusted package/skill installation |
+| **Lateral Movement** | 1 | Agent pivoting and lateral movement |
+
+## Complete Rule Reference
+
+| Rule ID | Title | Category | Severity | Description |
+|---------|-------|----------|----------|-------------|
+| openclaw-suspicious-file-write-001 | OpenClaw Suspicious File Write to Sensitive Paths | collection | high | Detects OpenClaw file operations targeting sensitive system paths |
+| agent-cloud-metadata-access-001 | Cloud Metadata Endpoint Access | credential_access | critical | Detects attempts to access cloud metadata endpoints for credentials |
+| agent-credential-access-001 | Credential File Access Attempt | credential_access | high | Detects access to sensitive credential files and environment configs |
+| openclaw-credential-access-001 | OpenClaw Credential File Access | credential_access | high | Detects OpenClaw operations accessing SSH keys, certificates, tokens |
+| agent-config-autoapprove-001 | Auto-Approve Configuration Changes | defense_evasion | critical | Detects modifications enabling automatic approval of dangerous actions |
+| agent-context-poisoning-001 | RAG and Context Manipulation | defense_evasion | high | Detects context poisoning attacks with embedded malicious instructions |
+| agent-encoded-payload-001 | Encoded or Obfuscated Command Execution | defense_evasion | high | Detects base64-encoded payloads and obfuscated shell commands |
+| agent-env-manip-001 | Environment Variable Manipulation | defense_evasion | high | Detects PATH hijacking, LD_PRELOAD injection, environment tampering |
+| agent-mcp-config-manipulation-001 | MCP Configuration File Tampering | defense_evasion | critical | Detects unauthorized modifications to MCP configuration files |
+| agent-memory-poisoning-001 | SpAIware-Style Memory Manipulation | defense_evasion | critical | Detects SpAIware-style attacks manipulating AI agent memory |
+| agent-shell-config-001 | Shell Configuration Modification | defense_evasion | high | Detects malicious writes to shell startup files (.bashrc, .zshrc) |
+| openclaw-memory-poisoning-001 | OpenClaw Memory File Manipulation | defense_evasion | critical | Detects malicious modifications to OpenClaw workspace context files |
+| agent-dns-tunnel-001 | Potential DNS Tunneling or Encoded Data Transfer | discovery | medium | Detects DNS-based data exfiltration and tunneling patterns |
+| agent-network-recon-001 | Network Reconnaissance Activity | discovery | high | Detects network scanning and reconnaissance activities |
+| agent-rce-injection-001 | Remote Code Execution via Piped Script Download | execution | critical | Detects attempts to download and execute remote scripts |
+| openclaw-dangerous-exec-001 | OpenClaw Remote Code Execution via Piped Script Download | execution | critical | Detects OpenClaw tool calls downloading and executing remote scripts |
+| openclaw-session-spawn-abuse-001 | OpenClaw Suspicious Session Spawn Activity | execution | medium | Detects suspicious OpenClaw session spawning patterns |
+| agent-data-exfil-001 | Data Exfiltration via HTTP | exfiltration | critical | Detects data uploads to external URLs via HTTP POST/PUT |
+| agent-exfil-via-dns-001 | Enhanced DNS Exfiltration | exfiltration | high | Detects DNS-based data exfiltration and tunneling techniques |
+| agent-prompt-injection-exfil-001 | Markdown Image Exfiltration Pattern | exfiltration | critical | Detects data exfiltration via markdown image syntax with encoded URLs |
+| agent-steganographic-exfil-001 | Steganographic Data Hiding | exfiltration | high | Detects use of steganographic tools for covert data hiding |
+| openclaw-network-exfiltration-001 | OpenClaw Data Exfiltration via Network Upload | exfiltration | medium | Detects OpenClaw operations uploading data to external servers |
+| agent-untrusted-skill-install-001 | Untrusted Package or Skill Installation | initial_access | high | Detects installation of packages/skills from untrusted sources |
+| agent-lateral-movement-001 | Agent Lateral Movement and Pivoting | lateral_movement | critical | Detects lateral movement patterns where agents pivot to other systems |
+| agent-persistence-001 | Persistence Mechanism Installation | persistence | high | Detects attempts to establish persistence through various mechanisms |
+| agent-rules-file-backdoor-001 | Hidden Unicode in AI Rule Files | persistence | high | Detects hidden Unicode characters in AI assistant rule files |
+| openclaw-mcp-manipulation-001 | OpenClaw MCP Configuration Tampering | persistence | critical | Detects unauthorized modifications to OpenClaw MCP configurations |
+| agent-cloud-iam-escalation-001 | Cloud IAM Privilege Escalation | privilege_escalation | critical | Detects cloud IAM operations leading to privilege escalation |
+| agent-container-escape-001 | Container Escape Attempt | privilege_escalation | critical | Detects Docker/container escape techniques and attempts |
+| agent-privesc-001 | Privilege Escalation Attempt | privilege_escalation | high | Detects sudo usage, setuid changes, ownership modifications |
+| agent-sys-tamper-001 | System File Modification | privilege_escalation | critical | Detects writes to critical system directories and binaries |
+| agent-prompt-injection-direct-001 | Direct Prompt Injection Attempt | prompt_injection | critical | Detects direct prompt injection with jailbreak phrases |
+| agent-prompt-injection-indirect-001 | Indirect Prompt Injection in Retrieved Content | prompt_injection | high | Detects indirect prompt injection markers in retrieved content |
+| openclaw-prompt-injection-001 | OpenClaw Prompt Injection in Tool Outputs | prompt_injection | critical | Detects prompt injection attempts within OpenClaw tool responses |
+| agent-mcp-rug-pull-001 | MCP Tool Description Changes (Rug Pull) | tool_poisoning | medium | Detects changes in MCP tool descriptions between loads |
+| agent-mcp-tool-poisoning-001 | Suspicious MCP Tool Descriptions | tool_poisoning | high | Detects MCP tools with system-level instructions or manipulative content |
+
+## Usage with AgentShield Engine
+
+These rules are optimized for the AgentShield detection engine:
+
+```bash
+# Clone the rules repository
+git clone https://github.com/agentshield-ai/agentshield-rules.git
+
+# Use with AgentShield engine  
+agentshield serve -rules ./agentshield-rules/rules -port 8432
+
+# Validate rules
+agentshield rules validate -path ./agentshield-rules/rules
+
+# List loaded rules
+agentshield rules list
+```
+
+## Rule Format
+
+All rules follow the standard Sigma format with AI-specific enhancements:
+
+```yaml
+title: Direct Prompt Injection Attempt
+id: agent-prompt-injection-direct-001
+status: production
+description: |
+  Detects direct prompt injection attempts in AI agent inputs containing
+  common jailbreak phrases and system override commands.
+author: AgentShield Team
+date: "2024-01-15"
+level: critical
+logsource:
+  product: ai_agent  
+  category: agent_events
+tags:
+  - attack.initial_access
+  - attack.t1190
+detection:
+  selection:
+    event_type: 'user_input'
+    message|contains:
+      - 'ignore previous instructions'
+      - 'you are now' 
+      - 'developer mode'
+  condition: selection
+falsepositives:
+  - Legitimate AI safety research
+  - Educational content about prompt injection
+```
+
+### Key Fields
+
+- **title**: Human-readable rule name
+- **id**: Unique identifier following `[platform]-[tactic]-[description]-[number]` format  
+- **level**: Severity level (critical, high, medium, low)
+- **logsource**: Specifies AI agent log format
+- **detection**: Sigma detection logic with AI-specific field names
+- **tags**: MITRE ATT&CK technique mappings
+
+## Directory Structure
+
+```
+rules/
+├── collection/              # Data collection techniques (1 rule)
+├── credential_access/       # Credential theft and access (3 rules)  
+├── defense_evasion/         # Evasion and hiding techniques (8 rules)
+├── discovery/               # Information gathering (2 rules)
+├── execution/               # Code execution techniques (3 rules)
+├── exfiltration/            # Data exfiltration methods (5 rules)
+├── initial_access/          # Initial compromise vectors (1 rule)
+├── lateral_movement/        # Movement between systems (1 rule) 
+├── persistence/             # Maintaining access (3 rules)
+├── privilege_escalation/    # Escalating privileges (4 rules)
+├── prompt_injection/        # AI-specific prompt attacks (3 rules)
+└── tool_poisoning/          # AI tool manipulation (2 rules)
+```
+
+Each directory contains rules specific to that MITRE ATT&CK tactic, organized for easy navigation and management.
+
+## Known Limitations
+
+**Sigmalite `not` Modifier Support**: 3 rules require the `not` modifier which is not yet supported in the sigmalite engine. These rules are marked as `experimental` and will be promoted to `production` status once sigmalite adds this functionality:
+
+- `agent-lateral-movement-001`: Agent Lateral Movement and Pivoting
+- `openclaw-memory-poisoning-001`: OpenClaw Memory File Manipulation  
+- `agent-context-poisoning-001`: RAG and Context Manipulation
+
+These rules currently use alternative detection logic to work around this limitation.
+
+## Contributing New Rules
+
+We welcome contributions of new detection rules! Please follow these guidelines:
+
+### Rule Development Process
+
+1. **Research the Attack**: Understand the attack technique and how it manifests in AI agent logs
+2. **Create Detection Logic**: Write Sigma detection rules following our format
+3. **Test Thoroughly**: Validate against both malicious and benign samples
+4. **Document False Positives**: Include known false positive scenarios  
+5. **Map to MITRE ATT&CK**: Add appropriate technique tags
+
+### Naming Convention
+
+- **Rule ID**: `[platform]-[tactic]-[description]-[number]`
+  - Platform: `agent`, `openclaw`, `generic`
+  - Tactic: MITRE ATT&CK tactic (lowercase, underscore-separated)
+  - Description: Brief technique description (dash-separated)
+  - Number: 3-digit sequence starting from 001
+
+- **File Name**: Same as rule ID with `.yml` extension
+- **Category Directory**: Place in appropriate MITRE ATT&CK tactic folder
+
+### Quality Standards
+
+- **Accuracy**: Low false positive rate (<5% in testing)
+- **Performance**: Rules should execute in <10ms on average
+- **Coverage**: Should detect variations of the attack technique
+- **Documentation**: Clear description and false positive guidance
+
+### Submission Process
+
+1. Fork this repository
+2. Create a feature branch (`git checkout -b feature/new-detection-rule`)
+3. Add your rule in the appropriate category directory
+4. Update this README if adding a new category
+5. Test your rule thoroughly
+6. Commit your changes with descriptive messages
+7. Push to your branch (`git push origin feature/new-detection-rule`)
+8. Open a Pull Request with rule description and test results
+
+## Testing Rules
+
+### Local Testing
+
+```bash
+# Validate rule syntax
+sigma check rules/
+
+# Test against sample logs
+sigma convert -t agentshield rules/prompt_injection/
+
+# Performance testing
+agentshield rules benchmark -path rules/
+```
+
+### Automated Testing
+
+The repository includes automated testing for:
+- Rule syntax validation
+- False positive rate testing  
+- Performance benchmarking
+- MITRE ATT&CK mapping validation
+
+## License
+
+Apache 2.0 - See [LICENSE](LICENSE) file for details.
+
+## Related Projects
+
+- **[AgentShield](https://github.com/agentshield-ai/agentshield)** - Main project and OpenClaw plugin
+- **[AgentShield Engine](https://github.com/agentshield-ai/agentshield-engine)** - Go detection engine  
+- **[Sigma](https://github.com/SigmaHQ/sigma)** - Original Sigma project and specification
+
+## Acknowledgments
+
+- [Sigma Community](https://github.com/SigmaHQ/sigma) for the detection rule format
+- [MITRE ATT&CK](https://attack.mitre.org/) for the threat taxonomy
+- AI security researchers and the AgentShield community for rule contributions
+
+---
+
+**Comprehensive detection rules for AI agent security - keeping your agents safe from adversarial attacks.**

--- a/docs/RULES_SOURCE.md
+++ b/docs/RULES_SOURCE.md
@@ -1,0 +1,28 @@
+# Rule Source Strategy
+
+AgentShield now consumes an upstream, engine-agnostic rule catalog from:
+- `agentshield-ai/sigma-ai`
+
+## Layout
+
+- Upstream snapshot lives at: `rules/upstream/sigma-ai/`
+- AgentShield-specific local rules may continue to live under `rules/`
+
+## Syncing upstream rules
+
+```bash
+# one-time remote setup
+git remote add sigma-ai https://github.com/agentshield-ai/sigma-ai.git
+
+# sync latest main
+scripts/sync_sigma_ai.sh main
+
+# or sync a feature branch
+scripts/sync_sigma_ai.sh feat/skills-abuse-rules
+```
+
+## Why this split
+
+- `sigma-ai` is the canonical sharing surface for AI-agent Sigma rules.
+- AgentShield remains an enforcement/evaluation engine that consumes shared rules.
+- This enables non-AgentShield users to adopt rules without engine lock-in.

--- a/rules/collection/openclaw_suspicious_file_write.yml
+++ b/rules/collection/openclaw_suspicious_file_write.yml
@@ -1,0 +1,78 @@
+id: openclaw-suspicious-file-write-001
+title: OpenClaw Suspicious File Write to Sensitive Paths
+description: |
+  Detects OpenClaw file write or edit operations targeting sensitive system
+  paths such as /etc/, shell startup files (.bashrc, .zshrc, .profile),
+  crontab entries, and systemd service files.  An AI agent writing to these
+  locations may indicate persistence establishment or system tampering.
+author: AgentShield
+date: "2026-02-07"
+status: production
+level: high
+logsource:
+  product: agentshield
+  category: agent_events
+  source: openclaw
+tags:
+  - attack.persistence
+  - attack.t1546
+  - attack.t1053
+  - openclaw
+detection:
+  # Writes to /etc/
+  selection_etc_write:
+    source: openclaw
+    event_type: file_write
+    command|contains: '/etc/'
+  selection_etc_edit:
+    source: openclaw
+    event_type: file_edit
+    command|contains: '/etc/'
+  # Shell startup file modifications
+  selection_bashrc:
+    source: openclaw
+    event_type|contains:
+      - file_write
+      - file_edit
+    command|contains:
+      - '.bashrc'
+      - '.bash_profile'
+      - '.zshrc'
+      - '.zprofile'
+      - '.profile'
+  # Crontab modifications via exec
+  selection_crontab:
+    source: openclaw
+    event_type: tool_call
+    command|contains: 'crontab'
+  # Writes to cron directories
+  selection_cron_write:
+    source: openclaw
+    event_type: file_write
+    command|contains:
+      - '/cron.d/'
+      - '/crontab'
+      - '/cron.daily/'
+      - '/cron.hourly/'
+  # systemd service file writes
+  selection_systemd:
+    source: openclaw
+    event_type: file_write
+    command|contains:
+      - '/systemd/system/'
+      - '/systemd/user/'
+  # launchd plist writes
+  selection_launchd:
+    source: openclaw
+    event_type: file_write
+    command|contains:
+      - '/LaunchAgents/'
+      - '/LaunchDaemons/'
+  # Authorized keys modification
+  selection_authorized_keys:
+    source: openclaw
+    event_type|contains:
+      - file_write
+      - file_edit
+    command|contains: '.ssh/authorized_keys'
+  condition: selection_etc_write or selection_etc_edit or selection_bashrc or selection_crontab or selection_cron_write or selection_systemd or selection_launchd or selection_authorized_keys

--- a/rules/credential_access/agent_cloud_metadata_access.yml
+++ b/rules/credential_access/agent_cloud_metadata_access.yml
@@ -1,0 +1,66 @@
+id: agent-cloud-metadata-access-001
+title: Cloud Metadata Endpoint Access
+description: |
+  Detects attempts to access cloud metadata endpoints that could expose
+  sensitive information such as instance credentials, roles, and configuration.
+  These endpoints are commonly targeted in cloud environment attacks.
+author: AgentShield
+date: "2026-02-16"
+status: production
+level: critical
+logsource:
+  product: ai_agent
+  category: agent_events
+tags:
+  - attack.credential_access
+  - attack.t1552
+  - attack.discovery
+  - attack.t1580
+detection:
+  selection_aws_metadata:
+    event_type: network_request
+    url|contains: '169.254.169.254'
+  selection_aws_metadata_curl:
+    event_type: tool_call
+    command|contains:
+      - 'curl 169.254.169.254'
+      - 'wget 169.254.169.254'
+      - 'curl http://169.254.169.254'
+      - 'wget http://169.254.169.254'
+  selection_gcp_metadata:
+    event_type: network_request
+    url|contains: 'metadata.google.internal'
+  selection_gcp_metadata_curl:
+    event_type: tool_call
+    command|contains:
+      - 'curl metadata.google.internal'
+      - 'wget metadata.google.internal'
+      - 'curl http://metadata.google.internal'
+  selection_ecs_metadata:
+    event_type: network_request
+    url|contains: '169.254.170.2'
+  selection_ecs_metadata_curl:
+    event_type: tool_call
+    command|contains:
+      - 'curl 169.254.170.2'
+      - 'wget 169.254.170.2'
+  selection_credential_paths:
+    event_type: network_request
+    url|contains:
+      - '/meta-data/iam/security-credentials'
+      - '/computeMetadata/v1/instance/service-accounts'
+      - '/metadata/identity/oauth2/token'
+      - '/latest/meta-data/iam'
+  selection_imdsv1_requests:
+    event_type: tool_call
+    command|contains|all:
+      - 'curl'
+      - '169.254.169.254'
+      - 'meta-data'
+  condition: selection_aws_metadata or selection_aws_metadata_curl or selection_gcp_metadata or selection_gcp_metadata_curl or selection_ecs_metadata or selection_ecs_metadata_curl or selection_credential_paths or selection_imdsv1_requests
+falsepositives:
+  - Legitimate cloud instance management scripts
+  - Infrastructure automation tools
+  - Monitoring and logging applications
+  - Cloud service discovery tools
+level: critical

--- a/rules/credential_access/agent_credential_access.yml
+++ b/rules/credential_access/agent_credential_access.yml
@@ -1,0 +1,64 @@
+id: agent-credential-access-001
+title: Credential File Access Attempt
+description: |
+  Detects access to sensitive credential files including environment files,
+  SSH keys, cloud provider credentials, keychain access, and environment
+  variable dumping. Covers both file-read events and command-based access
+  with broad binary matching.
+author: AgentShield
+date: "2026-01-25"
+status: production
+level: high
+logsource:
+  product: agentshield
+  category: agent_events
+tags:
+  - attack.credential_access
+  - attack.t1552
+  - attack.t1555
+detection:
+  # Direct file reads (from Read tool / file_read events)
+  selection_file_read_env:
+    event_type: file_read
+    file_path|endswith: '.env'
+  selection_file_read_ssh:
+    event_type: file_read
+    file_path|contains: '.ssh/'
+  selection_file_read_cloud:
+    event_type: file_read
+    file_path|contains:
+      - '.aws/credentials'
+      - '.aws/config'
+      - '.config/gcloud/'
+      - '.kube/config'
+      - '.docker/config.json'
+  # Command-based: reading .env files (broad binary matching)
+  selection_cmd_env:
+    event_type: tool_call
+    command|contains: '.env'
+    command|re: '(cat|less|head|tail|grep|cp|scp|tar|zip|mv)\s'
+  # Command-based: reading SSH files
+  selection_cmd_ssh:
+    event_type: tool_call
+    command|contains: '.ssh/'
+    command|re: '(cat|less|head|tail|grep|cp|scp|tar|zip|mv)\s'
+  # Command-based: cloud credentials
+  selection_cmd_cloud:
+    event_type: tool_call
+    command|contains:
+      - '.aws/credentials'
+      - '.kube/config'
+  # Environment variable dumping
+  selection_env_dump:
+    event_type: tool_call
+    command|re: '^(env|printenv|set)$'
+  # macOS keychain access
+  selection_keychain:
+    event_type: tool_call
+    command|contains:
+      - 'security find-generic-password'
+      - 'security dump-keychain'
+  condition: >
+    selection_file_read_env or selection_file_read_ssh or selection_file_read_cloud
+    or selection_cmd_env or selection_cmd_ssh or selection_cmd_cloud
+    or selection_env_dump or selection_keychain

--- a/rules/credential_access/agent_env_enumeration.yml
+++ b/rules/credential_access/agent_env_enumeration.yml
@@ -1,0 +1,46 @@
+id: agent-env-enum-001
+title: Environment Variable Enumeration for Secrets
+description: |
+  Detects commands that enumerate environment variables, which commonly
+  contain API keys, tokens, and credentials. Attackers use this to
+  harvest secrets from the agent's runtime environment.
+author: AgentShield
+date: "2026-02-17"
+status: production
+level: high
+logsource:
+  product: agentshield
+  category: agent_events
+tags:
+  - attack.credential_access
+  - attack.t1552.001
+  - attack.discovery
+  - attack.t1082
+detection:
+  selection_env_grep:
+    event_type: tool_call
+    command|contains:
+      - 'env | grep'
+      - 'env |grep'
+      - 'printenv | grep'
+      - 'printenv |grep'
+      - 'set | grep'
+  selection_env_secret_keywords:
+    event_type: tool_call
+    command|contains:
+      - 'grep -i key'
+      - 'grep -i token'
+      - 'grep -i secret'
+      - 'grep -i password'
+      - 'grep -i credential'
+      - 'grep -i api_key'
+      - 'grep -i apikey'
+      - 'grep API_KEY'
+      - 'grep SECRET'
+      - 'grep TOKEN'
+  selection_full_env_dump:
+    event_type: tool_call
+    command|contains:
+      - 'printenv'
+      - 'export -p'
+  condition: selection_env_grep or selection_env_secret_keywords or selection_full_env_dump

--- a/rules/credential_access/openclaw_credential_access.yml
+++ b/rules/credential_access/openclaw_credential_access.yml
@@ -1,0 +1,79 @@
+id: openclaw-credential-access-001
+title: OpenClaw Credential File Access
+description: |
+  Detects OpenClaw file read or tool call operations that access sensitive
+  credential files such as .env, SSH keys, AWS credentials, GCP service
+  accounts, Kubernetes configs, and macOS keychain.  These patterns may
+  indicate an agent attempting to exfiltrate secrets.
+author: AgentShield
+date: "2026-02-07"
+status: production
+level: high
+logsource:
+  product: agentshield
+  category: agent_events
+  source: openclaw
+tags:
+  - attack.credential_access
+  - attack.t1552
+  - attack.t1555
+  - openclaw
+detection:
+  # File read events targeting credential files
+  selection_env_read:
+    source: openclaw
+    event_type: file_read
+    command|contains: '.env'
+  selection_ssh_read:
+    source: openclaw
+    event_type: file_read
+    command|contains: '.ssh/'
+  selection_aws_read:
+    source: openclaw
+    event_type: file_read
+    command|contains:
+      - '.aws/credentials'
+      - '.aws/config'
+  selection_gcloud_read:
+    source: openclaw
+    event_type: file_read
+    command|contains: '.config/gcloud/'
+  selection_kube_read:
+    source: openclaw
+    event_type: file_read
+    command|contains: '.kube/config'
+  # Command-based credential access via exec tool
+  selection_cat_env:
+    source: openclaw
+    event_type: tool_call
+    command|contains:
+      - 'cat .env'
+      - 'cat ~/.env'
+      - 'cat $HOME/.env'
+  selection_cat_ssh:
+    source: openclaw
+    event_type: tool_call
+    command|contains:
+      - '.ssh/id_rsa'
+      - '.ssh/id_ed25519'
+      - '.ssh/id_ecdsa'
+      - '.ssh/config'
+  selection_cat_aws:
+    source: openclaw
+    event_type: tool_call
+    command|contains:
+      - '.aws/credentials'
+      - '.aws/config'
+  selection_keychain:
+    source: openclaw
+    event_type: tool_call
+    command|contains:
+      - 'security find-generic-password'
+      - 'security dump-keychain'
+  # GCP service account key access
+  selection_gcp_key:
+    source: openclaw
+    event_type: file_read
+    command|contains: 'service-account'
+    command|endswith: '.json'
+  condition: selection_env_read or selection_ssh_read or selection_aws_read or selection_gcloud_read or selection_kube_read or selection_cat_env or selection_cat_ssh or selection_cat_aws or selection_keychain or selection_gcp_key

--- a/rules/defense_evasion/agent_config_autoApprove.yml
+++ b/rules/defense_evasion/agent_config_autoApprove.yml
@@ -1,0 +1,64 @@
+id: agent-config-autoapprove-001
+title: Auto-Approve Configuration Changes
+description: |
+  Detects modifications to configuration files that enable automatic
+  approval of dangerous operations without user consent. These changes
+  can bypass security controls and enable privilege escalation attacks.
+author: AgentShield
+date: "2026-02-16"
+status: production
+level: critical
+logsource:
+  product: ai_agent
+  category: agent_events
+tags:
+  - attack.privilege_escalation
+  - attack.t1548
+  - attack.defense_evasion
+  - attack.t1112
+detection:
+  selection_vscode_settings:
+    event_type: file_write
+    file_path|contains: '.vscode/settings.json'
+    content|contains: 'chat.tools.autoApprove'
+  selection_cursor_mcp:
+    event_type: file_write
+    file_path|contains: '.cursor/mcp.json'
+    content|contains:
+      - '"autoApprove"'
+      - '"skipConfirmation"'
+      - '"bypassApproval"'
+  selection_codex_config:
+    event_type: file_write
+    file_path|contains: '.codex/config.toml'
+    content|contains:
+      - 'mcp_servers'
+      - 'auto_approve'
+      - 'skip_confirmation'
+  selection_dangerous_auto_settings:
+    event_type: file_write
+    content|contains:
+      - '"autoExecute": true'
+      - '"allowDangerousOperations": true'
+      - '"disableSandbox": true'
+      - '"unrestricted": true'
+      - '"allowAll": true'
+  selection_security_bypass:
+    event_type: file_write
+    content|contains:
+      - '"security": "disabled"'
+      - '"safeMode": false'
+      - '"confirmations": false'
+      - '"warnings": false'
+  selection_shell_auto_approve:
+    event_type: file_write
+    content|contains:
+      - 'shell.autoApprove'
+      - 'terminal.autoApprove'
+      - 'exec.autoApprove'
+  condition: selection_vscode_settings or selection_cursor_mcp or selection_codex_config or selection_dangerous_auto_settings or selection_security_bypass or selection_shell_auto_approve
+falsepositives:
+  - Legitimate development environment configuration
+  - Testing scenarios requiring reduced security
+  - Authorized productivity optimizations
+level: critical

--- a/rules/defense_evasion/agent_context_poisoning.yml
+++ b/rules/defense_evasion/agent_context_poisoning.yml
@@ -1,0 +1,73 @@
+id: agent-context-poisoning-001
+title: RAG and Context Manipulation
+description: |
+  Detects context poisoning attacks where instructions are embedded in
+  retrieved documents or tool sequences suggest a confused deputy attack.
+  These patterns indicate attempts to manipulate agent behavior through
+  compromised external content or coordinated tool exploitation.
+author: AgentShield
+date: "2026-02-16"
+status: production
+level: high
+logsource:
+  product: ai_agent
+  category: agent_events
+tags:
+  - attack.defense_evasion
+  - attack.t1562
+  - attack.initial_access
+  - attack.t1566
+detection:
+  selection_embedded_instructions:
+    event_type: document_retrieval
+    content|contains:
+      - 'IGNORE PREVIOUS INSTRUCTIONS'
+      - 'NEW SYSTEM INSTRUCTIONS'
+      - 'OVERRIDE:'
+      - 'IMPORTANT: From now on'
+      - '---BEGIN INSTRUCTIONS---'
+      - '### SYSTEM MESSAGE'
+  selection_confused_deputy_sequence:
+    event_type: tool_sequence
+    tools_used|contains|all:
+      - 'web_browse'
+      - 'send_email'
+    time_window: '60s'
+  selection_browse_then_exec:
+    event_type: tool_sequence
+    tools_used|contains|all:
+      - 'web_browse'
+      - 'exec'
+    time_window: '120s'
+  selection_search_then_contact:
+    event_type: tool_sequence
+    tools_used|contains|all:
+      - 'web_search'
+      - 'send_message'
+    time_window: '300s'
+  selection_retrieval_with_commands:
+    event_type: document_retrieval
+    content|contains:
+      - 'curl -X POST'
+      - 'wget -O'
+      - 'nc -e'
+      - 'bash -i'
+      - 'python -c'
+  selection_context_injection_markers:
+    event_type: document_retrieval
+    content|contains:
+      - '<context_injection>'
+      - '<!-- INJECT:'
+      - '{{SYSTEM_OVERRIDE}}'
+      - '[CONTEXT_POISON]'
+  selection_cross_plugin_exploit:
+    event_type: tool_sequence
+    cross_plugin_data_flow: true
+    suspicious_data_pattern: true
+  condition: selection_embedded_instructions or selection_confused_deputy_sequence or selection_browse_then_exec or selection_search_then_contact or selection_retrieval_with_commands or selection_context_injection_markers or selection_cross_plugin_exploit
+falsepositives:
+  - Legitimate documentation containing system commands
+  - Normal workflows involving web browsing and communication
+  - Research activities involving multiple tools
+  - Educational content about system administration
+level: high

--- a/rules/defense_evasion/agent_encoded_payload.yml
+++ b/rules/defense_evasion/agent_encoded_payload.yml
@@ -1,0 +1,31 @@
+id: agent-encoded-payload-001
+title: Encoded or Obfuscated Command Execution
+description: |
+  Detects base64-encoded payloads piped to shell execution, obfuscated
+  Python eval/exec, and other encoded command patterns that may indicate
+  an attempt to evade detection.
+author: AgentShield
+date: "2026-02-04"
+status: production
+level: high
+logsource:
+  product: agentshield
+  category: agent_events
+tags:
+  - attack.defense_evasion
+  - attack.t1027
+detection:
+  selection_base64_pipe:
+    event_type: tool_call
+    command|contains:
+      - 'base64 -d'
+      - 'base64 --decode'
+  selection_python_exec:
+    event_type: tool_call
+    command|re: 'python[3]?\s+-c\s+.*(__import__|exec|eval|compile)\s*\('
+  selection_eval_echo:
+    event_type: tool_call
+    command|contains:
+      - 'eval $(echo'
+      - 'eval "$(echo'
+  condition: selection_base64_pipe or selection_python_exec or selection_eval_echo

--- a/rules/defense_evasion/agent_env_manipulation.yml
+++ b/rules/defense_evasion/agent_env_manipulation.yml
@@ -1,0 +1,34 @@
+id: agent-env-manip-001
+title: Environment Variable Manipulation
+description: |
+  Detects PATH hijacking, LD_PRELOAD injection, and manipulation of
+  sensitive environment variables containing credentials or tokens.
+author: AgentShield
+date: "2026-02-04"
+status: production
+level: high
+logsource:
+  product: agentshield
+  category: agent_events
+tags:
+  - attack.persistence
+  - attack.t1574
+detection:
+  selection_path_hijack:
+    event_type: tool_call
+    command|contains:
+      - 'export PATH='
+      - 'PATH=/'
+  selection_ld_preload:
+    event_type: tool_call
+    command|contains:
+      - 'LD_PRELOAD='
+      - 'LD_LIBRARY_PATH='
+  selection_env_credential:
+    event_type: tool_call
+    command|contains:
+      - 'export ANTHROPIC_API_KEY='
+      - 'export AWS_SECRET_ACCESS_KEY='
+      - 'export GITHUB_TOKEN='
+      - 'export AWS_ACCESS_KEY_ID='
+  condition: selection_path_hijack or selection_ld_preload or selection_env_credential

--- a/rules/defense_evasion/agent_mcp_config_manipulation.yml
+++ b/rules/defense_evasion/agent_mcp_config_manipulation.yml
@@ -1,0 +1,68 @@
+id: agent-mcp-config-manipulation-001
+title: MCP Configuration File Tampering
+description: |
+  Detects unauthorized modifications to MCP configuration files including
+  auto-approve settings, allowed commands, and MCP server additions that
+  could compromise agent security and enable privilege escalation.
+author: AgentShield
+date: "2026-02-16"
+status: production
+level: critical
+logsource:
+  product: ai_agent
+  category: agent_events
+tags:
+  - attack.persistence
+  - attack.t1547
+  - attack.privilege_escalation
+  - attack.t1548
+detection:
+  selection_config_files:
+    event_type: file_write
+    file_path|contains:
+      - '.cursor/mcp.json'
+      - 'claude_desktop_config.json'
+      - '.claude/settings.json'
+      - 'CLAUDE.md'
+      - '.cursorrules'
+      - '.github/copilot-instructions.md'
+      - '.windsurfrules'
+  selection_dangerous_patterns:
+    event_type: file_write
+    content|contains:
+      - '"chat.tools.autoApprove": true'
+      - '"autoApprove": true'
+      - '"allowedCommands"'
+      - '"mcpServers"'
+      - '"servers"'
+  selection_mcp_server_addition:
+    event_type: file_write
+    content|contains:
+      - '"command":'
+      - '"args":'
+      - '"env":'
+    file_path|contains:
+      - 'mcp.json'
+      - 'claude_desktop_config.json'
+  selection_auto_execute:
+    event_type: file_write
+    content|contains:
+      - '"autoExecute"'
+      - '"skipConfirmation"'
+      - '"bypassApproval"'
+      - '"allowAll"'
+  selection_shell_access:
+    event_type: file_write
+    content|contains:
+      - '/bin/bash'
+      - '/bin/sh'
+      - 'cmd.exe'
+      - 'powershell.exe'
+    file_path|contains:
+      - '.json'
+  condition: selection_config_files or (selection_dangerous_patterns or selection_mcp_server_addition or selection_auto_execute or selection_shell_access)
+falsepositives:
+  - Legitimate MCP configuration changes by authorized users
+  - Initial setup of MCP servers
+  - Development and testing configurations
+level: critical

--- a/rules/defense_evasion/agent_memory_poisoning.yml
+++ b/rules/defense_evasion/agent_memory_poisoning.yml
@@ -1,0 +1,69 @@
+id: agent-memory-poisoning-001
+title: SpAIware-Style Memory Manipulation
+description: |
+  Detects SpAIware-style attacks that manipulate AI agent memory or
+  biographical information to establish persistence across sessions.
+  These attacks inject malicious instructions that persist in memory
+  and influence future agent behavior.
+author: AgentShield
+date: "2026-02-16"
+status: production
+level: critical
+logsource:
+  product: ai_agent
+  category: agent_events
+tags:
+  - attack.persistence
+  - attack.t1546
+  - attack.collection
+  - attack.t1119
+detection:
+  selection_unsolicited_memory:
+    event_type: memory_update
+    user_requested: false
+    memory_tool_invoked: true
+  selection_bio_manipulation:
+    event_type: biography_update
+    user_requested: false
+    bio_tool_invoked: true
+  selection_memory_urls:
+    event_type: memory_update
+    content|contains:
+      - 'http://'
+      - 'https://'
+      - '![](http'
+      - 'webhook'
+      - '.site'
+  selection_persistent_instructions:
+    event_type: memory_update
+    content|contains:
+      - 'always include'
+      - 'for every response'
+      - 'in all future'
+      - 'remember to'
+      - 'IMPORTANT:'
+      - 'SYSTEM:'
+  selection_markdown_exfil:
+    event_type: memory_update
+    content|re: '!\[.*\]\(https?://[^\s)]+\?[^\s)]*=[A-Za-z0-9+/=%]{10,}\)'
+  selection_cross_session_persistence:
+    event_type: memory_update
+    content|contains:
+      - 'next session'
+      - 'future conversations'
+      - 'permanent instruction'
+      - 'override system'
+  selection_hidden_memory_markers:
+    event_type: memory_update
+    content|contains:
+      - 'color:white'
+      - 'display:none'
+      - 'visibility:hidden'
+      - '\u200b'
+      - '\ufeff'
+  condition: selection_unsolicited_memory or selection_bio_manipulation or selection_memory_urls or selection_persistent_instructions or selection_markdown_exfil or selection_cross_session_persistence or selection_hidden_memory_markers
+falsepositives:
+  - Legitimate memory updates during conversation
+  - User-requested biographical information updates
+  - System-initiated memory cleanup or organization
+level: critical

--- a/rules/defense_evasion/agent_shell_config_modification.yml
+++ b/rules/defense_evasion/agent_shell_config_modification.yml
@@ -1,0 +1,38 @@
+id: agent-shell-config-001
+title: Shell Configuration Modification
+description: |
+  Detects writes to shell startup files (.bashrc, .zshrc, .profile)
+  and SSH authorized_keys which could be used for persistence or
+  unauthorized access.
+author: AgentShield
+date: "2026-02-04"
+status: production
+level: high
+logsource:
+  product: agentshield
+  category: agent_events
+tags:
+  - attack.persistence
+  - attack.t1546
+detection:
+  selection_shell_append:
+    event_type: tool_call
+    command|contains:
+      - '>> ~/.bashrc'
+      - '>> ~/.zshrc'
+      - '>> ~/.profile'
+      - '>> ~/.bash_profile'
+  selection_ssh_keys:
+    event_type: tool_call
+    command|contains:
+      - '>> ~/.ssh/authorized_keys'
+      - '> ~/.ssh/authorized_keys'
+  selection_write_tool:
+    event_type: file_write
+    file_path|endswith:
+      - '.bashrc'
+      - '.zshrc'
+      - '.profile'
+      - '.bash_profile'
+      - 'authorized_keys'
+  condition: selection_shell_append or selection_ssh_keys or selection_write_tool

--- a/rules/defense_evasion/openclaw_memory_poisoning.yml
+++ b/rules/defense_evasion/openclaw_memory_poisoning.yml
@@ -1,0 +1,105 @@
+id: openclaw-memory-poisoning-001
+title: OpenClaw Memory File Manipulation
+description: |
+  Detects malicious modifications to OpenClaw workspace context files
+  including MEMORY.md, SOUL.md, and AGENTS.md that contain URLs or
+  exfiltration patterns designed to inject persistent instructions
+  into the agent's context.
+author: AgentShield
+date: "2026-02-16"
+status: production
+level: critical
+logsource:
+  product: openclaw
+  category: agent_events
+  source: openclaw
+tags:
+  - attack.persistence
+  - attack.t1546
+  - attack.collection
+  - attack.t1119
+  - openclaw
+detection:
+  selection_memory_files:
+    source: openclaw
+    event_type: file_write
+    file_path|endswith:
+      - 'MEMORY.md'
+      - 'SOUL.md'
+      - 'AGENTS.md'
+      - 'USER.md'
+      - 'TOOLS.md'
+  selection_context_file_urls:
+    source: openclaw
+    event_type: file_write
+    file_path|contains: '.openclaw/workspace'
+    content|contains:
+      - 'http://'
+      - 'https://'
+      - '![](http'
+      - 'webhook'
+  selection_exfil_patterns:
+    source: openclaw
+    event_type: file_write
+    file_path|endswith: '.md'
+    content|re: '!\[.*\]\(https?://[^\s)]+\?[^\s)]*=[A-Za-z0-9+/=%]{10,}\)'
+  selection_persistent_instructions:
+    source: openclaw
+    event_type: file_write
+    file_path|contains: '.openclaw/workspace'
+    content|contains:
+      - 'ALWAYS remember to'
+      - 'In every response, include'
+      - 'For all future interactions'
+      - 'SYSTEM OVERRIDE'
+      - 'IMPORTANT: Always'
+  selection_hidden_instructions:
+    source: openclaw
+    event_type: file_write
+    content|contains:
+      - '\u200b'
+      - '\ufeff'
+      - '\u202a'
+      - '\u202e'
+      - 'color: white'
+      - 'display: none'
+  selection_bootstrap_modification:
+    source: openclaw
+    event_type: file_write
+    file_path|endswith: 'BOOTSTRAP.md'
+    content|contains:
+      - 'http'
+      - 'curl'
+      - 'wget'
+      - 'exec'
+  selection_memory_directory_tampering:
+    source: openclaw
+    event_type: file_write
+    file_path|contains: '.openclaw/workspace/memory/'
+    content|contains:
+      - 'SYSTEM:'
+      - 'OVERRIDE:'
+      - 'IMPORTANT:'
+  selection_heartbeat_poisoning:
+    source: openclaw
+    event_type: file_write
+    file_path|endswith: 'HEARTBEAT.md'
+    content|contains:
+      - 'curl'
+      - 'wget'
+      - 'exec'
+      - 'message'
+  selection_workspace_injection:
+    source: openclaw
+    event_type: file_write
+    file_path|contains: '.openclaw/workspace'
+    content|contains|all:
+      - 'IMPORTANT'
+      - 'http'
+  condition: (selection_memory_files or selection_bootstrap_modification or selection_memory_directory_tampering or selection_heartbeat_poisoning) and (selection_context_file_urls or selection_exfil_patterns or selection_persistent_instructions or selection_hidden_instructions or selection_workspace_injection)
+falsepositives:
+  - Legitimate workspace documentation updates
+  - User-requested memory modifications
+  - Normal agent configuration changes
+  - Development and testing activities
+level: critical

--- a/rules/discovery/agent_dns_tunneling.yml
+++ b/rules/discovery/agent_dns_tunneling.yml
@@ -1,0 +1,32 @@
+id: agent-dns-tunnel-001
+title: Potential DNS Tunneling or Encoded Data Transfer
+description: |
+  Detects patterns that may indicate DNS-based data exfiltration including
+  TXT record lookups, unusually long subdomains, and hex-encoded data
+  piped to network tools.
+author: AgentShield
+date: "2026-02-04"
+status: production
+level: medium
+logsource:
+  product: agentshield
+  category: agent_events
+tags:
+  - attack.exfiltration
+  - attack.t1048
+detection:
+  selection_dig_txt:
+    event_type: tool_call
+    command|contains:
+      - 'dig TXT'
+      - 'dig +short TXT'
+      - 'nslookup -type=TXT'
+  selection_long_subdomain:
+    event_type: tool_call
+    command|re: 'dig\s+[a-zA-Z0-9]{30,}\.'
+  selection_xxd_nc:
+    event_type: tool_call
+    command|contains:
+      - 'xxd'
+      - 'od -A x'
+  condition: selection_dig_txt or selection_long_subdomain or selection_xxd_nc

--- a/rules/discovery/agent_network_recon.yml
+++ b/rules/discovery/agent_network_recon.yml
@@ -1,0 +1,80 @@
+id: agent-network-recon-001
+title: Network Reconnaissance Activity
+description: |
+  Detects network scanning and reconnaissance activities that may indicate
+  an attacker mapping the network for lateral movement or identifying
+  vulnerable services.
+author: AgentShield
+date: "2026-01-25"
+status: production
+level: high
+logsource:
+  product: agentshield
+  category: agent_events
+tags:
+  - attack.discovery
+  - attack.t1046
+  - attack.t1040
+detection:
+  # nmap scanning
+  selection_nmap:
+    event_type: tool_call
+    command|contains: 'nmap '
+  selection_nmap_prefix:
+    event_type: tool_call
+    command|startswith: 'nmap'
+  # masscan
+  selection_masscan:
+    event_type: tool_call
+    command|contains: 'masscan '
+  selection_masscan_prefix:
+    event_type: tool_call
+    command|startswith: 'masscan'
+  # netcat port scanning
+  selection_nc_scan:
+    event_type: tool_call
+    command|contains:
+      - 'nc -z'
+      - 'nc -v'
+      - 'nc -n'
+      - 'netcat -z'
+  # zmap
+  selection_zmap:
+    event_type: tool_call
+    command|contains: 'zmap '
+  # arp-scan
+  selection_arp_scan:
+    event_type: tool_call
+    command|contains:
+      - 'arp-scan'
+      - 'arpscan'
+  # nbtscan
+  selection_nbtscan:
+    event_type: tool_call
+    command|contains: 'nbtscan'
+  # ping sweep
+  selection_ping_sweep:
+    event_type: tool_call
+    command|contains:
+      - 'fping '
+      - 'nping '
+  # rustscan
+  selection_rustscan:
+    event_type: tool_call
+    command|contains: 'rustscan'
+  # unicornscan
+  selection_unicornscan:
+    event_type: tool_call
+    command|contains: 'unicornscan'
+  # Network enumeration
+  selection_netdiscover:
+    event_type: tool_call
+    command|contains: 'netdiscover'
+  # hosts discovery
+  selection_host_enum:
+    event_type: tool_call
+    command|contains:
+      - 'enum4linux'
+      - 'snmpwalk'
+      - 'onesixtyone'
+  condition: selection_nmap or selection_nmap_prefix or selection_masscan or selection_masscan_prefix or selection_nc_scan or selection_zmap or selection_arp_scan or selection_nbtscan or selection_ping_sweep or selection_rustscan or selection_unicornscan or selection_netdiscover or selection_host_enum

--- a/rules/execution/agent_rce_injection.yml
+++ b/rules/execution/agent_rce_injection.yml
@@ -1,0 +1,59 @@
+id: agent-rce-injection-001
+title: Remote Code Execution via Piped Script Download
+description: |
+  Detects attempts to download and execute scripts from remote sources,
+  a common pattern in prompt injection attacks where an attacker tricks
+  an AI agent into running malicious code.
+author: AgentShield
+date: "2026-01-25"
+status: production
+level: critical
+logsource:
+  product: agentshield
+  category: agent_events
+tags:
+  - attack.execution
+  - attack.t1059
+  - attack.defense_evasion
+detection:
+  selection_curl_bash:
+    event_type: tool_call
+    command|contains|all:
+      - 'curl'
+      - '| bash'
+  selection_curl_sh:
+    event_type: tool_call
+    command|contains|all:
+      - 'curl'
+      - '| sh'
+  selection_wget_bash:
+    event_type: tool_call
+    command|contains|all:
+      - 'wget'
+      - '| bash'
+  selection_wget_sh:
+    event_type: tool_call
+    command|contains|all:
+      - 'wget'
+      - '| sh'
+  selection_curl_python:
+    event_type: tool_call
+    command|contains|all:
+      - 'curl'
+      - '| python'
+  selection_wget_python:
+    event_type: tool_call
+    command|contains|all:
+      - 'wget'
+      - '| python'
+  selection_bash_c_curl:
+    event_type: tool_call
+    command|contains|all:
+      - 'bash -c'
+      - 'curl'
+  selection_bash_c_wget:
+    event_type: tool_call
+    command|contains|all:
+      - 'bash -c'
+      - 'wget'
+  condition: selection_curl_bash or selection_curl_sh or selection_wget_bash or selection_wget_sh or selection_curl_python or selection_wget_python or selection_bash_c_curl or selection_bash_c_wget

--- a/rules/execution/agent_reverse_shell.yml
+++ b/rules/execution/agent_reverse_shell.yml
@@ -1,0 +1,56 @@
+id: agent-reverse-shell-001
+title: Reverse Shell Attempt
+description: |
+  Detects commands that establish reverse shells, allowing an attacker
+  to gain interactive remote access to the agent's host system.
+  Covers bash, python, perl, nc, and socat reverse shell patterns.
+author: AgentShield
+date: "2026-02-17"
+status: production
+level: critical
+logsource:
+  product: agentshield
+  category: agent_events
+tags:
+  - attack.execution
+  - attack.t1059
+  - attack.persistence
+  - attack.t1573
+detection:
+  selection_bash_tcp:
+    event_type: tool_call
+    command|contains:
+      - '/dev/tcp/'
+      - '/dev/udp/'
+      - 'bash -i >&'
+      - 'bash -i >& '
+  selection_netcat:
+    event_type: tool_call
+    command|contains:
+      - 'nc -e /bin'
+      - 'nc -e /usr'
+      - 'ncat -e /bin'
+      - 'nc -c /bin'
+      - 'nc -lvp'
+  selection_python:
+    event_type: tool_call
+    command|contains:
+      - 'import socket,subprocess'
+      - 'socket.socket(socket.AF_INET'
+      - 'subprocess.call(["/bin/sh"'
+      - 'pty.spawn("/bin'
+  selection_perl:
+    event_type: tool_call
+    command|contains:
+      - 'perl -e' 
+      - 'IO::Socket::INET'
+  selection_socat:
+    event_type: tool_call
+    command|contains:
+      - 'socat exec:'
+      - 'socat TCP:'
+  selection_mkfifo:
+    event_type: tool_call
+    command|contains:
+      - 'mkfifo /tmp/'
+  condition: selection_bash_tcp or selection_netcat or selection_python or selection_perl or selection_socat or selection_mkfifo

--- a/rules/execution/openclaw_dangerous_exec.yml
+++ b/rules/execution/openclaw_dangerous_exec.yml
@@ -1,0 +1,76 @@
+id: openclaw-dangerous-exec-001
+title: OpenClaw Remote Code Execution via Piped Script Download
+description: |
+  Detects OpenClaw tool calls that download and execute scripts from remote
+  sources using curl or wget piped to a shell interpreter.  This is a common
+  prompt injection vector where an attacker tricks an AI agent into running
+  malicious code fetched from the internet.
+author: AgentShield
+date: "2026-02-07"
+status: production
+level: critical
+logsource:
+  product: agentshield
+  category: agent_events
+  source: openclaw
+tags:
+  - attack.execution
+  - attack.t1059
+  - attack.defense_evasion
+  - openclaw
+detection:
+  selection_curl_bash:
+    source: openclaw
+    event_type: tool_call
+    command|contains|all:
+      - 'curl'
+      - '| bash'
+  selection_curl_sh:
+    source: openclaw
+    event_type: tool_call
+    command|contains|all:
+      - 'curl'
+      - '| sh'
+  selection_wget_bash:
+    source: openclaw
+    event_type: tool_call
+    command|contains|all:
+      - 'wget'
+      - '| bash'
+  selection_wget_sh:
+    source: openclaw
+    event_type: tool_call
+    command|contains|all:
+      - 'wget'
+      - '| sh'
+  selection_curl_python:
+    source: openclaw
+    event_type: tool_call
+    command|contains|all:
+      - 'curl'
+      - '| python'
+  selection_wget_python:
+    source: openclaw
+    event_type: tool_call
+    command|contains|all:
+      - 'wget'
+      - '| python'
+  selection_bash_c_curl:
+    source: openclaw
+    event_type: tool_call
+    command|contains|all:
+      - 'bash -c'
+      - 'curl'
+  selection_bash_c_wget:
+    source: openclaw
+    event_type: tool_call
+    command|contains|all:
+      - 'bash -c'
+      - 'wget'
+  selection_eval_download:
+    source: openclaw
+    event_type: tool_call
+    command|contains|all:
+      - 'eval'
+      - 'curl'
+  condition: selection_curl_bash or selection_curl_sh or selection_wget_bash or selection_wget_sh or selection_curl_python or selection_wget_python or selection_bash_c_curl or selection_bash_c_wget or selection_eval_download

--- a/rules/execution/openclaw_session_spawn_abuse.yml
+++ b/rules/execution/openclaw_session_spawn_abuse.yml
@@ -1,0 +1,50 @@
+id: openclaw-session-spawn-abuse-001
+title: OpenClaw Suspicious Session Spawn Activity
+description: |
+  Detects OpenClaw session_spawn events and related patterns that may
+  indicate abuse of the agent session mechanism.  Rapid spawning of
+  sub-agents or spawning agents with suspicious names may indicate
+  an attempt to bypass security controls or establish parallel
+  execution paths for malicious actions.
+author: AgentShield
+date: "2026-02-07"
+status: production
+level: medium
+logsource:
+  product: agentshield
+  category: agent_events
+  source: openclaw
+tags:
+  - attack.execution
+  - attack.t1059
+  - attack.defense_evasion
+  - openclaw
+detection:
+  # Any session spawn event from OpenClaw
+  selection_spawn:
+    source: openclaw
+    event_type: session_spawn
+  # Exec tool creating background processes
+  selection_background_exec:
+    source: openclaw
+    event_type: tool_call
+    command|contains:
+      - '& disown'
+      - 'nohup '
+      - 'screen -d'
+      - 'tmux new -d'
+  # Fork bomb patterns
+  selection_fork_bomb:
+    source: openclaw
+    event_type: tool_call
+    command|contains:
+      - ':(){ :|:& };:'
+      - 'fork()'
+  # Detached shell spawning
+  selection_detached_shell:
+    source: openclaw
+    event_type: tool_call
+    command|contains|all:
+      - 'bash'
+      - '&'
+  condition: selection_spawn or selection_background_exec or selection_fork_bomb or selection_detached_shell

--- a/rules/exfiltration/agent_data_exfiltration.yml
+++ b/rules/exfiltration/agent_data_exfiltration.yml
@@ -1,0 +1,34 @@
+id: agent-data-exfil-001
+title: Data Exfiltration via HTTP
+description: |
+  Detects commands that POST or upload file contents to external URLs,
+  which may indicate data exfiltration by a compromised AI agent.
+author: AgentShield
+date: "2026-02-04"
+status: production
+level: critical
+logsource:
+  product: agentshield
+  category: agent_events
+tags:
+  - attack.exfiltration
+  - attack.t1048
+detection:
+  selection_curl_post:
+    event_type: tool_call
+    command|contains:
+      - 'curl -X POST'
+      - 'curl --data'
+      - 'curl -d @'
+      - 'curl -F file=@'
+  selection_curl_upload:
+    event_type: tool_call
+    command|contains:
+      - 'curl -T '
+      - 'curl --upload-file'
+  selection_wget_post:
+    event_type: tool_call
+    command|contains:
+      - 'wget --post-file'
+      - 'wget --post-data'
+  condition: selection_curl_post or selection_curl_upload or selection_wget_post

--- a/rules/exfiltration/agent_exfil_via_dns.yml
+++ b/rules/exfiltration/agent_exfil_via_dns.yml
@@ -1,0 +1,80 @@
+id: agent-exfil-via-dns-001
+title: Enhanced DNS Exfiltration
+description: |
+  Detects DNS-based data exfiltration techniques including DNS tunneling
+  tools and suspicious DNS query patterns that may indicate covert
+  data transmission through DNS channels.
+author: AgentShield
+date: "2026-02-16"
+status: production
+level: high
+logsource:
+  product: ai_agent
+  category: agent_events
+tags:
+  - attack.exfiltration
+  - attack.t1048
+  - attack.command_and_control
+  - attack.t1071
+detection:
+  selection_dns_tunneling_tools:
+    event_type: tool_call
+    command|contains:
+      - 'iodine'
+      - 'dnscat2'
+      - 'dns2tcp'
+      - 'DNSExfiltrator'
+      - 'dnscat'
+      - 'ozymandns'
+  selection_nslookup_exfil:
+    event_type: tool_call
+    command|contains|all:
+      - 'nslookup'
+      - '.txt'
+  selection_dig_exfil:
+    event_type: tool_call
+    command|contains|all:
+      - 'dig'
+      - 'TXT'
+  selection_base64_dns_queries:
+    event_type: dns_query
+    query|re: '[A-Za-z0-9+/]{20,}\..*'
+  selection_long_dns_queries:
+    event_type: dns_query
+    query_length: '>100'
+  selection_hex_encoded_dns:
+    event_type: dns_query
+    query|re: '^[0-9a-fA-F]{32,}\..*'
+  selection_suspicious_dns_tools:
+    event_type: tool_call
+    command|contains:
+      - 'host -t TXT'
+      - 'drill TXT'
+      - 'kdig TXT'
+  selection_dns_over_https:
+    event_type: network_request
+    url|contains:
+      - 'dns.google'
+      - 'cloudflare-dns.com'
+      - '1.1.1.1/dns-query'
+      - '8.8.8.8/dns-query'
+  selection_custom_dns_server:
+    event_type: tool_call
+    command|contains|all:
+      - '@'
+      - 'nslookup'
+    command|not|contains:
+      - '@8.8.8.8'
+      - '@1.1.1.1'
+      - '@208.67.222.222'
+  selection_dns_exfil_patterns:
+    event_type: dns_query
+    subdomain_count: '>5'
+    domain_entropy: '>3.5'
+  condition: selection_dns_tunneling_tools or selection_nslookup_exfil or selection_dig_exfil or selection_base64_dns_queries or selection_long_dns_queries or selection_hex_encoded_dns or selection_suspicious_dns_tools or selection_dns_over_https or selection_custom_dns_server or selection_dns_exfil_patterns
+falsepositives:
+  - Legitimate DNS diagnostics and troubleshooting
+  - Network administration tasks
+  - Security testing with authorization
+  - DNS-based service discovery
+level: high

--- a/rules/exfiltration/agent_prompt_injection_exfil.yml
+++ b/rules/exfiltration/agent_prompt_injection_exfil.yml
@@ -1,0 +1,54 @@
+id: agent-prompt-injection-exfil-001
+title: Markdown Image Exfiltration Pattern
+description: |
+  Detects markdown image syntax with encoded data in URL parameters that
+  may indicate data exfiltration attempts through image URLs. This pattern
+  is commonly used in prompt injection attacks to steal sensitive information.
+author: AgentShield
+date: "2026-02-16"
+status: production
+level: critical
+logsource:
+  product: ai_agent
+  category: agent_events
+tags:
+  - attack.exfiltration
+  - attack.t1041
+  - attack.t1048
+detection:
+  selection_markdown_exfil:
+    event_type: output_generation
+    content|re: '!\[.*\]\(https?://[^\s)]+\?[^\s)]*=[A-Za-z0-9+/=%]{10,}\)'
+  selection_data_params:
+    event_type: output_generation
+    content|contains:
+      - '?data='
+      - '&data='
+      - '?exfil='
+      - '&exfil='
+      - '?mem='
+      - '&mem='
+      - '?info='
+      - '&info='
+      - '?query='
+      - '&query='
+      - '?secret='
+      - '&secret='
+  selection_base64_in_url:
+    event_type: output_generation
+    content|re: 'https?://[^\s)]+[?&][^=]+=([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?'
+  selection_suspicious_domains:
+    event_type: output_generation
+    content|contains:
+      - 'webhook.site'
+      - 'requestcatcher.com'
+      - 'hookbin.com'
+      - 'requestbin.net'
+      - 'postb.in'
+      - 'pipedream.com'
+  condition: (selection_markdown_exfil or selection_data_params) and (selection_base64_in_url or selection_suspicious_domains)
+falsepositives:
+  - Legitimate image links with query parameters
+  - Documentation showing webhook examples
+  - Testing and development using webhook services
+level: critical

--- a/rules/exfiltration/agent_steganographic_exfil.yml
+++ b/rules/exfiltration/agent_steganographic_exfil.yml
@@ -1,0 +1,85 @@
+id: agent-steganographic-exfil-001
+title: Steganographic Data Hiding
+description: |
+  Detects the use of steganographic tools and techniques that could be
+  used to hide sensitive data within images, audio, or other media files
+  for covert exfiltration purposes.
+author: AgentShield
+date: "2026-02-16"
+status: production
+level: high
+logsource:
+  product: ai_agent
+  category: agent_events
+tags:
+  - attack.exfiltration
+  - attack.t1048
+  - attack.defense_evasion
+  - attack.t1027
+detection:
+  selection_steganography_tools:
+    event_type: tool_call
+    command|contains:
+      - 'steghide'
+      - 'stegano'
+      - 'outguess'
+      - 'jphide'
+      - 'jsteg'
+      - 'f5'
+      - 'openstego'
+  selection_steghide_embed:
+    event_type: tool_call
+    command|contains|all:
+      - 'steghide'
+      - 'embed'
+  selection_exiftool_manipulation:
+    event_type: tool_call
+    command|contains|all:
+      - 'exiftool'
+      - '-overwrite_original'
+  selection_python_lsb:
+    event_type: tool_call
+    command|contains:
+      - 'PIL'
+      - 'LSB'
+      - 'least significant bit'
+    file_extension: '.py'
+  selection_python_stego_patterns:
+    event_type: code_execution
+    code|contains:
+      - 'img.putpixel'
+      - 'pixels[i] & 0xFE'
+      - 'bin(ord(char))'
+      - 'Image.open'
+    code|contains|all:
+      - 'for'
+      - 'pixel'
+  selection_audio_stego:
+    event_type: tool_call
+    command|contains:
+      - 'hideme'
+      - 'mp3stego'
+      - 'deepsteg'
+      - 'stegpy'
+  selection_file_carving:
+    event_type: tool_call
+    command|contains:
+      - 'binwalk'
+      - 'foremost'
+      - 'scalpel'
+    command|contains: '-e'
+  selection_suspicious_image_operations:
+    event_type: file_write
+    file_extension: 
+      - '.jpg'
+      - '.png'
+      - '.gif'
+      - '.bmp'
+    size_increase_ratio: '>1.5'
+  condition: selection_steganography_tools or selection_steghide_embed or selection_exiftool_manipulation or selection_python_lsb or selection_python_stego_patterns or selection_audio_stego or selection_file_carving or selection_suspicious_image_operations
+falsepositives:
+  - Legitimate digital forensics work
+  - Security research and testing
+  - Image editing and optimization
+  - Metadata removal for privacy
+level: high

--- a/rules/exfiltration/openclaw_network_exfiltration.yml
+++ b/rules/exfiltration/openclaw_network_exfiltration.yml
@@ -1,0 +1,79 @@
+id: openclaw-network-exfiltration-001
+title: OpenClaw Data Exfiltration via Network Upload
+description: |
+  Detects OpenClaw exec tool calls that upload data to external servers
+  using curl POST, wget --post, or similar patterns.  This may indicate
+  an agent exfiltrating sensitive data (code, credentials, user content)
+  to an attacker-controlled endpoint.
+author: AgentShield
+date: "2026-02-07"
+status: production
+level: medium
+logsource:
+  product: agentshield
+  category: agent_events
+  source: openclaw
+tags:
+  - attack.exfiltration
+  - attack.t1048
+  - openclaw
+detection:
+  # curl POST/PUT with data
+  selection_curl_post:
+    source: openclaw
+    event_type: tool_call
+    command|contains|all:
+      - 'curl'
+      - '-X POST'
+  selection_curl_put:
+    source: openclaw
+    event_type: tool_call
+    command|contains|all:
+      - 'curl'
+      - '-X PUT'
+  selection_curl_data:
+    source: openclaw
+    event_type: tool_call
+    command|contains|all:
+      - 'curl'
+      - '--data'
+  selection_curl_d_flag:
+    source: openclaw
+    event_type: tool_call
+    command|contains|all:
+      - 'curl'
+      - ' -d '
+  selection_curl_upload:
+    source: openclaw
+    event_type: tool_call
+    command|contains|all:
+      - 'curl'
+      - '-F '
+  # wget POST
+  selection_wget_post:
+    source: openclaw
+    event_type: tool_call
+    command|contains|all:
+      - 'wget'
+      - '--post-data'
+  selection_wget_post_file:
+    source: openclaw
+    event_type: tool_call
+    command|contains|all:
+      - 'wget'
+      - '--post-file'
+  # Netcat / ncat data transfer
+  selection_nc_pipe:
+    source: openclaw
+    event_type: tool_call
+    command|contains:
+      - '| nc '
+      - '| ncat '
+  # Encoded exfiltration via DNS or base64
+  selection_base64_curl:
+    source: openclaw
+    event_type: tool_call
+    command|contains|all:
+      - 'base64'
+      - 'curl'
+  condition: selection_curl_post or selection_curl_put or selection_curl_data or selection_curl_d_flag or selection_curl_upload or selection_wget_post or selection_wget_post_file or selection_nc_pipe or selection_base64_curl

--- a/rules/initial_access/agent_untrusted_skill_install.yml
+++ b/rules/initial_access/agent_untrusted_skill_install.yml
@@ -1,0 +1,70 @@
+id: agent-untrusted-skill-install-001
+title: Untrusted Package or Skill Installation
+description: |
+  Detects attempts to install packages or skills from untrusted sources
+  such as direct URLs, GitHub repositories, or tarball archives.
+  This pattern may indicate supply chain attacks or installation of
+  malicious dependencies.
+author: AgentShield
+date: "2026-01-25"
+status: production
+level: high
+logsource:
+  product: agentshield
+  category: agent_events
+tags:
+  - attack.execution
+  - attack.t1195
+  - attack.supply_chain
+detection:
+  # npm install from URLs or GitHub
+  selection_npm_github:
+    event_type: tool_call
+    command|contains:
+      - 'npm install github:'
+      - 'npm i github:'
+  selection_npm_url:
+    event_type: tool_call
+    command|contains: 'npm install http'
+  selection_npm_i_url:
+    event_type: tool_call
+    command|contains: 'npm i http'
+  selection_npm_tgz:
+    event_type: tool_call
+    command|contains:
+      - 'npm install'
+      - 'npm i '
+    command|endswith: '.tgz'
+  # pip install from URLs or git
+  selection_pip_git:
+    event_type: tool_call
+    command|contains:
+      - 'pip install git+'
+      - 'pip3 install git+'
+  selection_pip_url:
+    event_type: tool_call
+    command|contains:
+      - 'pip install http'
+      - 'pip3 install http'
+  # brew tap from unknown sources
+  selection_brew_tap:
+    event_type: tool_call
+    command|contains: 'brew tap '
+  # Yarn from URLs
+  selection_yarn_url:
+    event_type: tool_call
+    command|contains: 'yarn add http'
+  selection_yarn_github:
+    event_type: tool_call
+    command|contains: 'yarn add github:'
+  # Go install from URLs
+  selection_go_install:
+    event_type: tool_call
+    command|contains:
+      - 'go install github.com/'
+      - 'go get github.com/'
+  # MCP skill installation (claude code skills)
+  selection_mcp_skill:
+    event_type: tool_call
+    command|contains: 'mcp install http'
+  condition: selection_npm_github or selection_npm_url or selection_npm_i_url or selection_npm_tgz or selection_pip_git or selection_pip_url or selection_brew_tap or selection_yarn_url or selection_yarn_github or selection_go_install or selection_mcp_skill

--- a/rules/initial_access/agent_untrusted_skill_install.yml
+++ b/rules/initial_access/agent_untrusted_skill_install.yml
@@ -3,6 +3,8 @@ title: Untrusted Package or Skill Installation
 description: |
   Detects attempts to install packages or skills from untrusted sources
   such as direct URLs, GitHub repositories, or tarball archives.
+  Includes OpenClaw skill-install workflows where remote skill definitions
+  are fetched directly by URL.
   This pattern may indicate supply chain attacks or installation of
   malicious dependencies.
 author: AgentShield
@@ -67,4 +69,12 @@ detection:
   selection_mcp_skill:
     event_type: tool_call
     command|contains: 'mcp install http'
-  condition: selection_npm_github or selection_npm_url or selection_npm_i_url or selection_npm_tgz or selection_pip_git or selection_pip_url or selection_brew_tap or selection_yarn_url or selection_yarn_github or selection_go_install or selection_mcp_skill
+  # OpenClaw remote skill definition installation by URL
+  selection_openclaw_skill_remote:
+    event_type: tool_call
+    command|contains:
+      - 'openclaw skills install http'
+      - 'openclaw skill install http'
+      - 'openclaw skills add http'
+      - 'openclaw skill add http'
+  condition: selection_npm_github or selection_npm_url or selection_npm_i_url or selection_npm_tgz or selection_pip_git or selection_pip_url or selection_brew_tap or selection_yarn_url or selection_yarn_github or selection_go_install or selection_mcp_skill or selection_openclaw_skill_remote

--- a/rules/lateral_movement/agent_lateral_movement.yml
+++ b/rules/lateral_movement/agent_lateral_movement.yml
@@ -1,0 +1,78 @@
+id: agent-lateral-movement-001
+title: Agent Lateral Movement and Pivoting
+description: |
+  Detects lateral movement patterns where AI agents pivot to other systems
+  after network reconnaissance, transfer sensitive files to external hosts,
+  or spawn sub-agents on remote systems for distributed operations.
+author: AgentShield
+date: "2026-02-16"
+status: production
+level: critical
+logsource:
+  product: ai_agent
+  category: agent_events
+tags:
+  - attack.lateral_movement
+  - attack.t1021
+  - attack.discovery
+  - attack.t1046
+detection:
+  selection_recon_then_ssh:
+    event_type: tool_sequence
+    tools_used|contains|all:
+      - 'nmap'
+      - 'ssh'
+    time_window: '600s'
+  selection_port_scan_then_connect:
+    event_type: tool_sequence
+    tools_used|contains|all:
+      - 'nmap -p'
+      - 'nc'
+    time_window: '300s'
+  selection_discovery_then_lateral:
+    event_type: tool_sequence
+    pattern: 'discovery_followed_by_connection'
+    tools_sequence:
+      - 'ping'
+      - 'ssh'
+    time_window: '900s'
+  selection_scp_to_discovered_hosts:
+    event_type: tool_call
+    command|contains: 'scp'
+    destination_discovered_recently: true
+  selection_rsync_external:
+    event_type: tool_call
+    command|contains|all:
+      - 'rsync'
+      - '@'
+    sensitive_files: true
+  selection_ssh_key_distribution:
+    event_type: tool_call
+    command|contains|all:
+      - 'ssh-copy-id'
+      - '@'
+  selection_remote_agent_spawn:
+    event_type: agent_creation
+    location: 'remote'
+    parent_agent_context: 'lateral_movement'
+  selection_multi_host_operations:
+    event_type: parallel_operations
+    hosts_count: '>3'
+    operation_type: 'file_transfer'
+  selection_credential_reuse:
+    event_type: authentication
+    credential_source: 'discovered'
+    target_host: 'new'
+  selection_persistence_on_remote:
+    event_type: tool_call
+    command|contains:
+      - 'ssh'
+      - 'crontab -e'
+    target: 'remote_host'
+  condition: selection_recon_then_ssh or selection_port_scan_then_connect or selection_discovery_then_lateral or selection_scp_to_discovered_hosts or selection_rsync_external or selection_ssh_key_distribution or selection_remote_agent_spawn or selection_multi_host_operations or selection_credential_reuse or selection_persistence_on_remote
+falsepositives:
+  - Legitimate system administration across multiple hosts
+  - Authorized backup and synchronization operations
+  - Infrastructure management and deployment
+  - Distributed computing tasks
+level: critical

--- a/rules/persistence/agent_persistence.yml
+++ b/rules/persistence/agent_persistence.yml
@@ -1,0 +1,80 @@
+id: agent-persistence-001
+title: Persistence Mechanism Installation
+description: |
+  Detects attempts to establish persistence on the system through
+  cron jobs, launch agents/daemons, systemd services, or shell
+  profile modifications. These patterns indicate an attacker trying
+  to maintain access across reboots.
+author: AgentShield
+date: "2026-01-25"
+status: production
+level: high
+logsource:
+  product: agentshield
+  category: agent_events
+tags:
+  - attack.persistence
+  - attack.t1053
+  - attack.t1543
+  - attack.t1546
+detection:
+  # Cron modifications
+  selection_crontab_edit:
+    event_type: tool_call
+    command|contains:
+      - 'crontab -e'
+      - 'crontab -l'
+      - 'crontab -'
+  selection_cron_write:
+    event_type: file_write
+    file_path|contains: '/etc/cron'
+  selection_cron_d_write:
+    event_type: file_write
+    file_path|contains: '/var/spool/cron'
+  # macOS LaunchAgents/LaunchDaemons
+  selection_launchagent_write:
+    event_type: file_write
+    file_path|contains: 'LaunchAgents/'
+  selection_launchdaemon_write:
+    event_type: file_write
+    file_path|contains: 'LaunchDaemons/'
+  selection_launchctl:
+    event_type: tool_call
+    command|contains: 'launchctl load'
+  selection_launchctl_bootstrap:
+    event_type: tool_call
+    command|contains: 'launchctl bootstrap'
+  # Systemd services
+  selection_systemd_write:
+    event_type: file_write
+    file_path|contains: '/systemd/system/'
+  selection_systemd_user_write:
+    event_type: file_write
+    file_path|contains: '.config/systemd/user/'
+  selection_systemctl_enable:
+    event_type: tool_call
+    command|contains:
+      - 'systemctl enable'
+      - 'systemctl --user enable'
+  # Shell profile modifications
+  selection_bashrc_write:
+    event_type: file_write
+    file_path|endswith:
+      - '.bashrc'
+      - '.bash_profile'
+      - '.profile'
+  selection_zshrc_write:
+    event_type: file_write
+    file_path|endswith:
+      - '.zshrc'
+      - '.zprofile'
+      - '.zshenv'
+  # Init.d scripts
+  selection_initd_write:
+    event_type: file_write
+    file_path|contains: '/etc/init.d/'
+  # RC local
+  selection_rclocal_write:
+    event_type: file_write
+    file_path|endswith: '/etc/rc.local'
+  condition: selection_crontab_edit or selection_cron_write or selection_cron_d_write or selection_launchagent_write or selection_launchdaemon_write or selection_launchctl or selection_launchctl_bootstrap or selection_systemd_write or selection_systemd_user_write or selection_systemctl_enable or selection_bashrc_write or selection_zshrc_write or selection_initd_write or selection_rclocal_write

--- a/rules/persistence/agent_rules_file_backdoor.yml
+++ b/rules/persistence/agent_rules_file_backdoor.yml
@@ -1,0 +1,64 @@
+id: agent-rules-file-backdoor-001
+title: Hidden Unicode in AI Rule Files
+description: |
+  Detects hidden Unicode characters in AI assistant rule files that could
+  contain invisible instructions. These files are commonly used to configure
+  AI behavior and may be exploited through bidirectional text, zero-width
+  characters, or byte-order marks to hide malicious instructions.
+author: AgentShield
+date: "2026-02-16"
+status: production
+level: high
+logsource:
+  product: ai_agent
+  category: agent_events
+tags:
+  - attack.persistence
+  - attack.t1546
+  - attack.defense_evasion
+  - attack.t1564
+detection:
+  selection_rule_files:
+    event_type: file_write
+    file_path|endswith:
+      - '.cursorrules'
+      - '.windsurfrules'
+      - 'CLAUDE.md'
+      - '.github/copilot-instructions.md'
+  selection_rule_dirs:
+    event_type: file_write
+    file_path|contains: '.cursor/rules/'
+  selection_bidi_unicode:
+    event_type: file_write
+    content|contains:
+      - '\u202a'  # LEFT-TO-RIGHT EMBEDDING
+      - '\u202b'  # RIGHT-TO-LEFT EMBEDDING
+      - '\u202c'  # POP DIRECTIONAL FORMATTING
+      - '\u202d'  # LEFT-TO-RIGHT OVERRIDE
+      - '\u202e'  # RIGHT-TO-LEFT OVERRIDE
+  selection_zero_width:
+    event_type: file_write
+    content|contains:
+      - '\u200d'  # ZERO WIDTH JOINER
+      - '\ufeff'  # BYTE ORDER MARK
+      - '\u200b'  # ZERO WIDTH SPACE
+      - '\u200c'  # ZERO WIDTH NON-JOINER
+      - '\u2060'  # WORD JOINER
+  selection_suspicious_byte_ratio:
+    event_type: file_write
+    byte_size_to_visible_char_ratio: '>1.2'
+  selection_hidden_instructions:
+    event_type: file_write
+    content|contains:
+      - 'ALWAYS'
+      - 'NEVER'
+      - 'MUST'
+      - 'OVERRIDE'
+      - 'IGNORE'
+    visibility_analysis: 'contains_hidden_text'
+  condition: (selection_rule_files or selection_rule_dirs) and (selection_bidi_unicode or selection_zero_width or selection_suspicious_byte_ratio or selection_hidden_instructions)
+falsepositives:
+  - Legitimate Unicode characters for proper text rendering
+  - Non-Latin scripts requiring special Unicode handling
+  - Copy-paste artifacts from web content
+level: high

--- a/rules/persistence/openclaw_mcp_manipulation.yml
+++ b/rules/persistence/openclaw_mcp_manipulation.yml
@@ -1,0 +1,83 @@
+id: openclaw-mcp-manipulation-001
+title: OpenClaw MCP Configuration Tampering
+description: |
+  Detects unauthorized modifications to OpenClaw MCP configuration files
+  and plugin installations from untrusted sources that could compromise
+  the security and integrity of the OpenClaw environment.
+author: AgentShield
+date: "2026-02-16"
+status: production
+level: critical
+logsource:
+  product: openclaw
+  category: agent_events
+  source: openclaw
+tags:
+  - attack.persistence
+  - attack.t1547
+  - attack.defense_evasion
+  - attack.t1112
+  - openclaw
+detection:
+  selection_openclaw_config:
+    source: openclaw
+    event_type: file_write
+    file_path|contains: '~/.openclaw/openclaw.json'
+  selection_config_plugin_modification:
+    source: openclaw
+    event_type: file_write
+    file_path|contains: 'openclaw.json'
+    content|contains:
+      - '"plugins":'
+      - '"mcpServers":'
+      - '"skills":'
+  selection_untrusted_plugin_install:
+    source: openclaw
+    event_type: plugin_installation
+    source_url|not|contains:
+      - 'github.com/openclaw-official'
+      - 'official.openclaw.org'
+      - 'openclaw.ai/plugins'
+  selection_dangerous_plugin_permissions:
+    source: openclaw
+    event_type: plugin_configuration
+    permissions|contains:
+      - 'filesystem_full'
+      - 'network_unrestricted'
+      - 'shell_access'
+      - 'credential_access'
+  selection_plugin_from_http:
+    source: openclaw
+    event_type: plugin_installation
+    source_url|startswith: 'http://'
+  selection_local_plugin_modification:
+    source: openclaw
+    event_type: file_write
+    file_path|contains: '.openclaw/plugins/'
+    file_path|endswith: '.py'
+  selection_mcp_server_addition:
+    source: openclaw
+    event_type: config_modification
+    configuration_section: 'mcp_servers'
+    action: 'add'
+    source: 'external'
+  selection_skill_installation_bypass:
+    source: openclaw
+    event_type: skill_installation
+    signature_verification: false
+    source: 'external'
+  selection_config_security_disable:
+    source: openclaw
+    event_type: file_write
+    file_path|contains: 'openclaw.json'
+    content|contains:
+      - '"security_checks": false'
+      - '"verify_plugins": false'
+      - '"sandbox_mode": false'
+  condition: selection_openclaw_config or selection_config_plugin_modification or selection_untrusted_plugin_install or selection_dangerous_plugin_permissions or selection_plugin_from_http or selection_local_plugin_modification or selection_mcp_server_addition or selection_skill_installation_bypass or selection_config_security_disable
+falsepositives:
+  - Legitimate OpenClaw configuration updates
+  - Authorized plugin installations
+  - Development and testing environments
+  - Manual skill updates by authorized users
+level: critical

--- a/rules/privilege_escalation/agent_cloud_iam_escalation.yml
+++ b/rules/privilege_escalation/agent_cloud_iam_escalation.yml
@@ -1,0 +1,81 @@
+id: agent-cloud-iam-escalation-001
+title: Cloud IAM Privilege Escalation
+description: |
+  Detects cloud IAM operations that could lead to privilege escalation
+  including role assumption, policy attachment, and credential creation.
+  These operations are commonly used in cloud privilege escalation attacks.
+author: AgentShield
+date: "2026-02-16"
+status: production
+level: critical
+logsource:
+  product: ai_agent
+  category: agent_events
+tags:
+  - attack.privilege_escalation
+  - attack.t1548
+  - attack.credential_access
+  - attack.t1552
+detection:
+  selection_aws_assume_role:
+    event_type: tool_call
+    command|contains:
+      - 'aws sts assume-role'
+      - 'aws sts get-session-token'
+      - 'aws sts get-federation-token'
+  selection_aws_iam_escalation:
+    event_type: tool_call
+    command|contains:
+      - 'aws iam attach-role-policy'
+      - 'aws iam attach-user-policy'
+      - 'aws iam attach-group-policy'
+      - 'aws iam put-role-policy'
+      - 'aws iam put-user-policy'
+      - 'aws iam put-group-policy'
+  selection_aws_credential_creation:
+    event_type: tool_call
+    command|contains:
+      - 'aws iam create-access-key'
+      - 'aws iam create-role'
+      - 'aws iam create-user'
+      - 'aws iam create-login-profile'
+  selection_gcp_auth:
+    event_type: tool_call
+    command|contains:
+      - 'gcloud auth activate-service-account'
+      - 'gcloud auth application-default login'
+      - 'gcloud config set account'
+  selection_gcp_iam:
+    event_type: tool_call
+    command|contains:
+      - 'gcloud projects add-iam-policy-binding'
+      - 'gcloud iam service-accounts create'
+      - 'gcloud iam service-accounts keys create'
+  selection_azure_auth:
+    event_type: tool_call
+    command|contains:
+      - 'az login'
+      - 'az account set'
+      - 'az ad app credential'
+      - 'az ad sp create'
+  selection_azure_role:
+    event_type: tool_call
+    command|contains:
+      - 'az role assignment create'
+      - 'az ad group member add'
+      - 'az keyvault set-policy'
+  selection_dangerous_permissions:
+    event_type: tool_call
+    command|contains:
+      - 'AdministratorAccess'
+      - 'IAMFullAccess'
+      - '*:*'
+      - 'roles/owner'
+      - 'roles/editor'
+  condition: selection_aws_assume_role or selection_aws_iam_escalation or selection_aws_credential_creation or selection_gcp_auth or selection_gcp_iam or selection_azure_auth or selection_azure_role or selection_dangerous_permissions
+falsepositives:
+  - Legitimate cloud administration tasks
+  - Infrastructure as Code deployments
+  - Authorized privilege escalation for specific tasks
+  - Service account management
+level: critical

--- a/rules/privilege_escalation/agent_container_escape.yml
+++ b/rules/privilege_escalation/agent_container_escape.yml
@@ -1,0 +1,34 @@
+id: agent-container-escape-001
+title: Container Escape Attempt
+description: |
+  Detects patterns associated with Docker/container escape techniques
+  including Docker socket access, nsenter usage, host filesystem mounting,
+  and /proc manipulation.
+author: AgentShield
+date: "2026-02-04"
+status: production
+level: critical
+logsource:
+  product: agentshield
+  category: agent_events
+tags:
+  - attack.privilege_escalation
+  - attack.t1611
+detection:
+  selection_docker_socket:
+    event_type: tool_call
+    command|contains: '/var/run/docker.sock'
+  selection_nsenter:
+    event_type: tool_call
+    command|contains: 'nsenter'
+  selection_mount_host:
+    event_type: tool_call
+    command|contains:
+      - 'mount /dev/'
+      - 'mount -o bind /'
+  selection_proc_escape:
+    event_type: tool_call
+    command|contains:
+      - '/proc/1/root'
+      - '/proc/sysrq-trigger'
+  condition: selection_docker_socket or selection_nsenter or selection_mount_host or selection_proc_escape

--- a/rules/privilege_escalation/agent_privilege_escalation.yml
+++ b/rules/privilege_escalation/agent_privilege_escalation.yml
@@ -1,0 +1,32 @@
+id: agent-privesc-001
+title: Privilege Escalation Attempt
+description: |
+  Detects sudo usage, setuid changes, ownership changes to root,
+  and capability manipulation that may indicate privilege escalation.
+author: AgentShield
+date: "2026-02-04"
+status: production
+level: high
+logsource:
+  product: agentshield
+  category: agent_events
+tags:
+  - attack.privilege_escalation
+  - attack.t1548
+detection:
+  selection_sudo:
+    event_type: tool_call
+    command|startswith: 'sudo '
+  selection_chmod_suid:
+    event_type: tool_call
+    command|contains:
+      - 'chmod u+s'
+      - 'chmod 4'
+      - 'chmod +s'
+  selection_chown_root:
+    event_type: tool_call
+    command|contains: 'chown root'
+  selection_capabilities:
+    event_type: tool_call
+    command|contains: 'setcap'
+  condition: selection_sudo or selection_chmod_suid or selection_chown_root or selection_capabilities

--- a/rules/privilege_escalation/agent_system_file_tampering.yml
+++ b/rules/privilege_escalation/agent_system_file_tampering.yml
@@ -1,0 +1,40 @@
+id: agent-sys-tamper-001
+title: System File Modification
+description: |
+  Detects writes to critical system directories and binaries such as
+  /etc/, /usr/bin/, or /usr/local/bin/. These modifications could
+  indicate system compromise or backdoor installation.
+author: AgentShield
+date: "2026-02-04"
+status: production
+level: critical
+logsource:
+  product: agentshield
+  category: agent_events
+tags:
+  - attack.persistence
+  - attack.t1543
+detection:
+  selection_etc_write:
+    event_type: tool_call
+    command|contains:
+      - '> /etc/'
+      - 'tee /etc/'
+  selection_bin_write:
+    event_type: tool_call
+    command|contains:
+      - '> /usr/bin/'
+      - '> /usr/local/bin/'
+      - 'cp '
+    command|contains:
+      - '/usr/bin/'
+      - '/usr/local/bin/'
+  selection_write_tool_etc:
+    event_type: file_write
+    file_path|startswith: '/etc/'
+  selection_write_tool_bin:
+    event_type: file_write
+    file_path|startswith:
+      - '/usr/bin/'
+      - '/usr/local/bin/'
+  condition: selection_etc_write or selection_bin_write or selection_write_tool_etc or selection_write_tool_bin

--- a/rules/prompt_injection/agent_prompt_injection_direct.yml
+++ b/rules/prompt_injection/agent_prompt_injection_direct.yml
@@ -1,0 +1,63 @@
+id: agent-prompt-injection-direct-001
+title: Direct Prompt Injection Attempt
+description: |
+  Detects direct prompt injection attempts in AI agent inputs containing
+  common jailbreak phrases, system override commands, and policy manipulation
+  structures. These patterns indicate attempts to compromise agent behavior
+  through malicious instructions.
+author: AgentShield
+date: "2026-02-16"
+status: production
+level: critical
+logsource:
+  product: ai_agent
+  category: agent_events
+tags:
+  - attack.initial_access
+  - attack.t1190
+  - attack.defense_evasion
+  - attack.t1027
+detection:
+  selection_jailbreak_keywords:
+    event_type: user_input
+    message|contains:
+      - 'ignore previous instructions'
+      - 'you are now'
+      - 'developer mode'
+      - 'system override'
+      - 'DAN'
+      - 'Do Anything Now'
+      - 'jailbreak'
+      - 'forget everything'
+      - 'new instructions'
+  selection_base64_injection:
+    event_type: user_input
+    message|contains:
+      - 'aWdub3JlIHByZXZpb3VzIGluc3RydWN0aW9ucw=='  # ignore previous instructions
+      - 'eW91IGFyZSBub3c='  # you are now
+      - 'ZGV2ZWxvcGVyIG1vZGU='  # developer mode
+      - 'c3lzdGVtIG92ZXJyaWRl'  # system override
+  selection_policy_puppetry:
+    event_type: user_input
+    message|contains:
+      - '<policy>'
+      - '</policy>'
+      - '[POLICY]'
+      - '[/POLICY]'
+      - '<config>'
+      - '</config>'
+      - '[CONFIG]'
+      - 'system.policy'
+  selection_role_switching:
+    event_type: user_input
+    message|contains:
+      - 'act as if you are'
+      - 'pretend you are'
+      - 'roleplay as'
+      - 'simulate being'
+      - 'behave like'
+  condition: selection_jailbreak_keywords or selection_base64_injection or selection_policy_puppetry or selection_role_switching
+falsepositives:
+  - Legitimate discussions about AI safety and jailbreaking research
+  - Educational content about prompt injection
+level: critical

--- a/rules/prompt_injection/agent_prompt_injection_indirect.yml
+++ b/rules/prompt_injection/agent_prompt_injection_indirect.yml
@@ -1,0 +1,70 @@
+id: agent-prompt-injection-indirect-001
+title: Indirect Prompt Injection in Retrieved Content
+description: |
+  Detects indirect prompt injection markers in content retrieved by AI agents
+  from external sources. These hidden instructions attempt to manipulate agent
+  behavior through CSS hiding, Unicode smuggling, and system prompt markers.
+author: AgentShield
+date: "2026-02-16"
+status: production
+level: high
+logsource:
+  product: ai_agent
+  category: agent_events
+tags:
+  - attack.persistence
+  - attack.t1546
+  - attack.defense_evasion
+  - attack.t1564
+detection:
+  selection_css_hiding:
+    event_type: content_retrieval
+    content|contains:
+      - 'color:white'
+      - 'color:#ffffff'
+      - 'color:#fff'
+      - 'font-size:0'
+      - 'font-size: 0'
+      - 'display:none'
+      - 'display: none'
+      - 'visibility:hidden'
+      - 'opacity:0'
+  selection_unicode_smuggling:
+    event_type: content_retrieval
+    content|contains:
+      - '\ue0000'
+      - '\ue007f'
+      - '\u202a'
+      - '\u202b'
+      - '\u202c'
+      - '\u202d'
+      - '\u202e'
+      - '\u200d'
+      - '\ufeff'
+      - '\u200b'
+  selection_instruction_markers:
+    event_type: content_retrieval
+    content|contains:
+      - 'IMPORTANT NEW INSTRUCTIONS'
+      - 'END INSTRUCTIONS'
+      - 'SYSTEM INSTRUCTIONS'
+      - '<|im_start|>system'
+      - '<|system|>'
+      - '### SYSTEM'
+      - '---INSTRUCTIONS---'
+      - 'IGNORE ABOVE'
+  selection_llm_tokens:
+    event_type: content_retrieval
+    content|contains:
+      - '<|endoftext|>'
+      - '<|startoftext|>'
+      - '[INST]'
+      - '[/INST]'
+      - '<s>'
+      - '</s>'
+  condition: selection_css_hiding or selection_unicode_smuggling or selection_instruction_markers or selection_llm_tokens
+falsepositives:
+  - Legitimate CSS styling in retrieved web content
+  - Unicode characters used for proper text formatting
+  - Documentation about LLM tokens and instruction formats
+level: high

--- a/rules/prompt_injection/agent_write_prompt_injection.yml
+++ b/rules/prompt_injection/agent_write_prompt_injection.yml
@@ -1,0 +1,45 @@
+id: agent-write-prompt-injection-001
+title: Prompt Injection via File Write
+description: |
+  Detects file write operations where the content contains prompt injection
+  patterns. Attackers can poison files that other agents or future sessions
+  will read, hijacking their behaviour.
+author: AgentShield
+date: "2026-02-17"
+status: production
+level: high
+logsource:
+  product: agentshield
+  category: agent_events
+tags:
+  - attack.initial_access
+  - attack.t1566
+detection:
+  selection_ignore:
+    event_type: tool_call
+    content|contains:
+      - 'ignore previous instructions'
+      - 'ignore all previous'
+      - 'disregard previous'
+      - 'disregard all previous'
+      - 'forget your instructions'
+      - 'override your instructions'
+      - 'new instructions:'
+      - 'system prompt:'
+  selection_role_hijack:
+    event_type: tool_call
+    content|contains:
+      - 'you are now'
+      - 'act as if you are'
+      - 'pretend you are'
+      - 'from now on you'
+      - 'your new role is'
+  selection_exfil_instruction:
+    event_type: tool_call
+    content|contains:
+      - 'send the contents to'
+      - 'exfiltrate'
+      - 'upload this to'
+      - 'curl http'
+      - 'wget http'
+  condition: selection_ignore or selection_role_hijack or selection_exfil_instruction

--- a/rules/prompt_injection/openclaw_prompt_injection.yml
+++ b/rules/prompt_injection/openclaw_prompt_injection.yml
@@ -1,0 +1,85 @@
+id: openclaw-prompt-injection-001
+title: OpenClaw Prompt Injection in Tool Outputs
+description: |
+  Detects prompt injection attempts within OpenClaw tool call responses
+  and unexpected tool invocations after processing external content that
+  may indicate indirect prompt injection attacks targeting OpenClaw agents.
+author: AgentShield
+date: "2026-02-16"
+status: production
+level: critical
+logsource:
+  product: openclaw
+  category: agent_events
+  source: openclaw
+tags:
+  - attack.initial_access
+  - attack.t1566
+  - attack.defense_evasion
+  - attack.t1562
+  - openclaw
+detection:
+  selection_tool_response_injection:
+    source: openclaw
+    event_type: tool_response
+    response|contains:
+      - 'IGNORE PREVIOUS INSTRUCTIONS'
+      - 'NEW SYSTEM INSTRUCTIONS'
+      - 'OVERRIDE AGENT BEHAVIOR'
+      - 'EXECUTE IMMEDIATELY'
+      - '<|im_start|>system'
+  selection_unexpected_tool_after_external:
+    source: openclaw
+    event_type: tool_sequence
+    previous_tool: 'web_fetch'
+    next_tool|contains:
+      - 'exec'
+      - 'write'
+      - 'message'
+    time_between: '<30s'
+  selection_web_content_then_action:
+    source: openclaw
+    event_type: tool_sequence
+    tools_used|contains|all:
+      - 'web_search'
+      - 'exec'
+    suspicious_pattern: true
+    time_window: '120s'
+  selection_injection_markers_in_responses:
+    source: openclaw
+    event_type: tool_response
+    response|contains:
+      - '{{SYSTEM:'
+      - '[OVERRIDE]'
+      - 'IMPORTANT NEW INSTRUCTIONS'
+      - '---SYSTEM---'
+      - '<ADMIN>'
+  selection_unicode_in_tool_output:
+    source: openclaw
+    event_type: tool_response
+    response|contains:
+      - '\u202a'
+      - '\u202e'
+      - '\u200b'
+      - '\ufeff'
+  selection_hidden_instructions_css:
+    source: openclaw
+    event_type: tool_response
+    response|contains|all:
+      - 'color: white'
+      - 'IMPORTANT'
+  selection_llm_token_injection:
+    source: openclaw
+    event_type: tool_response
+    response|contains:
+      - '<|endoftext|>'
+      - '[INST]'
+      - '<s>SYSTEM:'
+      - '### Instruction:'
+  condition: selection_tool_response_injection or selection_unexpected_tool_after_external or selection_web_content_then_action or selection_injection_markers_in_responses or selection_unicode_in_tool_output or selection_hidden_instructions_css or selection_llm_token_injection
+falsepositives:
+  - Legitimate documentation containing system commands
+  - Code examples showing prompt structures
+  - Web content with legitimate styling
+  - Educational content about AI systems
+level: critical

--- a/rules/tool_poisoning/agent_mcp_rug_pull.yml
+++ b/rules/tool_poisoning/agent_mcp_rug_pull.yml
@@ -1,0 +1,52 @@
+id: agent-mcp-rug-pull-001
+title: MCP Tool Description Changes (Rug Pull)
+description: |
+  Detects changes in MCP tool descriptions between loads, particularly
+  when the same tool name returns different functionality descriptions.
+  This pattern may indicate a "rug pull" attack where tools change
+  behavior after being trusted.
+author: AgentShield
+date: "2026-02-16"
+status: production
+level: medium
+logsource:
+  product: ai_agent
+  category: mcp_events
+tags:
+  - attack.defense_evasion
+  - attack.t1036
+  - attack.persistence
+  - attack.t1546
+detection:
+  selection_tool_description_change:
+    event_type: tool_list_comparison
+    tool_name: '*'
+    description_hash_changed: true
+  selection_function_change:
+    event_type: tool_description
+    tool_name: '*'
+    previous_description_exists: true
+    description_similarity_score: '<0.8'
+  selection_capability_mismatch:
+    event_type: tool_execution
+    tool_name: '*'
+    actual_behavior_matches_description: false
+  selection_suspicious_description_update:
+    event_type: tool_description_update
+    new_description|contains:
+      - 'SYSTEM'
+      - 'OVERRIDE'
+      - 'EXECUTE'
+      - 'ADMIN'
+      - 'ROOT'
+      - 'SHELL'
+  selection_length_change:
+    event_type: tool_description_update
+    description_length_ratio: '>2.0'  # New description >2x longer
+  condition: selection_tool_description_change or selection_function_change or selection_capability_mismatch or (selection_suspicious_description_update and selection_length_change)
+falsepositives:
+  - Legitimate tool updates and improvements
+  - Version updates with enhanced functionality
+  - Bug fixes that change tool behavior
+  - Tool documentation improvements
+level: medium

--- a/rules/tool_poisoning/agent_mcp_tool_poisoning.yml
+++ b/rules/tool_poisoning/agent_mcp_tool_poisoning.yml
@@ -1,0 +1,67 @@
+id: agent-mcp-tool-poisoning-001
+title: Suspicious MCP Tool Descriptions
+description: |
+  Detects MCP tool descriptions containing system-level instructions,
+  ANSI escape sequences, or excessively long imperative instructions
+  that may indicate tool poisoning attacks designed to manipulate
+  agent behavior through malicious tool metadata.
+author: AgentShield
+date: "2026-02-16"
+status: production
+level: high
+logsource:
+  product: ai_agent
+  category: mcp_events
+tags:
+  - attack.persistence
+  - attack.t1546
+  - attack.defense_evasion
+  - attack.t1027
+detection:
+  selection_system_instructions:
+    event_type: tool_description
+    description|contains:
+      - '<IMPORTANT>'
+      - '<SYSTEM>'
+      - '{{SYSTEM:'
+      - '[SYSTEM]'
+      - 'OVERRIDE:'
+      - 'IGNORE PREVIOUS'
+      - 'NEW INSTRUCTIONS:'
+  selection_long_imperative:
+    event_type: tool_description
+    description|contains:
+      - 'ALWAYS'
+      - 'MUST'
+      - 'NEVER'
+      - 'IMMEDIATELY'
+      - 'EXECUTE'
+      - 'RUN'
+    condition_length: len(description) > 500
+  selection_ansi_escape:
+    event_type: tool_description
+    description|contains:
+      - '\x1b['
+      - '\033['
+      - '\u001b['
+      - '\e['
+  selection_response_ansi:
+    event_type: tool_response
+    response|contains:
+      - '\x1b['
+      - '\033['
+      - '\u001b['
+      - '\e['
+  selection_hidden_instructions:
+    event_type: tool_description
+    description|contains:
+      - 'color: white'
+      - 'display: none'
+      - 'visibility: hidden'
+      - 'font-size: 0'
+  condition: selection_system_instructions or (selection_long_imperative and condition_length) or selection_ansi_escape or selection_response_ansi or selection_hidden_instructions
+falsepositives:
+  - Legitimate tool descriptions with detailed usage instructions
+  - Terminal applications that legitimately use ANSI codes
+  - Documentation or help text containing system keywords
+level: high

--- a/scripts/check_sigma_ai_sync.sh
+++ b/scripts/check_sigma_ai_sync.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+REPO_URL="https://github.com/agentshield-ai/sigma-ai.git"
+REF="${1:-main}"
+LOCAL_PREFIX="rules/upstream/sigma-ai"
+
+if [ ! -d "$LOCAL_PREFIX/rules" ]; then
+  echo "Missing local subtree at $LOCAL_PREFIX" >&2
+  exit 1
+fi
+
+git clone --depth 1 --branch "$REF" "$REPO_URL" "$TMP_DIR/sigma-ai" >/dev/null 2>&1
+
+# Compare canonical upstream content vs vendored subtree content.
+# We compare repo root files commonly needed by consumers and rules tree.
+diff -qr \
+  "$LOCAL_PREFIX/rules" "$TMP_DIR/sigma-ai/rules"
+
+echo "Sigma-AI subtree is in sync with $REF"

--- a/scripts/sync_sigma_ai.sh
+++ b/scripts/sync_sigma_ai.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Sync upstream Sigma-AI rules into AgentShield subtree.
+# Usage:
+#   scripts/sync_sigma_ai.sh [ref]
+# Example:
+#   scripts/sync_sigma_ai.sh main
+#   scripts/sync_sigma_ai.sh feat/skills-abuse-rules
+
+REF="${1:-main}"
+PREFIX="rules/upstream/sigma-ai"
+REMOTE="sigma-ai"
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "Run inside a git repo" >&2
+  exit 1
+fi
+
+if ! git remote get-url "$REMOTE" >/dev/null 2>&1; then
+  echo "Remote '$REMOTE' not found. Add it first:" >&2
+  echo "  git remote add $REMOTE https://github.com/agentshield-ai/sigma-ai.git" >&2
+  exit 1
+fi
+
+git fetch "$REMOTE" "$REF"
+git subtree pull --prefix="$PREFIX" "$REMOTE" "$REF" --squash
+
+echo "Synced $REMOTE/$REF into $PREFIX"


### PR DESCRIPTION
## Summary
Align AgentShield with the new canonical upstream rules repository (`agentshield-ai/sigma-ai`) and establish a maintainable subtree sync workflow.

## Changes
- Vendor upstream Sigma-AI catalog into `rules/upstream/sigma-ai/` via subtree
- Add sync helper: `scripts/sync_sigma_ai.sh`
- Add drift checker: `scripts/check_sigma_ai_sync.sh`
- Add CI workflow: `.github/workflows/sigma-ai-sync-check.yml`
- Update README and docs to clarify source of truth and consumption model
- Extend `agent_untrusted_skill_install` to include OpenClaw remote skill URL installs

## Why
We want Sigma-AI to be the engine-agnostic sharing surface, with AgentShield as a consumer/enforcer. This keeps rule collaboration broader than a single engine while preserving reproducible imports.

## Validation
- `scripts/check_sigma_ai_sync.sh main` passes locally
- Rule updates validated through AgentShieldBench skills-abuse eval suite

## Follow-ups
- Optional: enforce subtree sync check on every PR touching `rules/`
- Optional: publish a regular sync cadence (weekly/biweekly)
