### PR TITLE
security: Greptile remediation pass 1 (TLS clarity, ReDoS guard, health-check mode)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,7 @@ The engine uses YAML configuration with environment variable substitution. Defau
 ```yaml
 # HTTP Server Configuration
 server:
-  addr: "0.0.0.0"                    # Bind address (default: "0.0.0.0")
+  addr: "0.0.0.0"                    # Bind address (default: "127.0.0.1")
   port: 8433                         # HTTP port (default: 8433)
 
 # Authentication Configuration
@@ -45,6 +45,7 @@ triage:
   base_url: ""                      # Custom base URL for OpenRouter, etc (optional)
   max_tokens: 500                   # Max response tokens (default: 500)
   timeout_sec: 10                   # Request timeout seconds (default: 10)
+  health_check_mode: "full"         # "full" (default) or "connectivity"
 
 # Deep Triage Configuration (async OpenClaw sub-agent)
 deep_triage:
@@ -98,8 +99,10 @@ server:
 - `AGENTSHIELD_SERVER_PORT`
 
 **Defaults:**
-- `addr`: "0.0.0.0"
+- `addr`: "127.0.0.1"
 - `port`: 8433
+
+**TLS Note:** AgentShield does not terminate TLS. When using a non-localhost bind address (anything other than `127.0.0.1`, `localhost`, or `::1`), you must place a TLS-terminating reverse proxy (e.g., nginx, Caddy) in front of the engine. See the [Deployment Guide](deployment.md#transport-security-tls) for details.
 
 ### Authentication Configuration
 
@@ -205,6 +208,7 @@ triage:
   base_url: "https://openrouter.ai/api/v1"
   max_tokens: 500
   timeout_sec: 10
+  health_check_mode: "connectivity"  # "full" (default) or "connectivity"
 ```
 
 **Fields:**
@@ -215,6 +219,13 @@ triage:
 - `base_url` (string): Custom API base URL (useful for OpenRouter)
 - `max_tokens` (int): Maximum response tokens
 - `timeout_sec` (int): Request timeout in seconds
+- `health_check_mode` (string): Health check strategy - "full" or "connectivity" (default: "full")
+
+**Health Check Modes:**
+- `full` (default): Makes a minimal completion API call to verify end-to-end functionality. Costs a small number of tokens per check.
+- `connectivity`: Validates API key and network connectivity without spending tokens. For OpenAI, uses the free `/v1/models` endpoint. For Anthropic, uses a minimal request (`max_tokens=1`, single-char prompt) since no free endpoint is available.
+
+Use `connectivity` mode in development or high-frequency health check scenarios to reduce token costs.
 
 **Provider Models:**
 - **OpenAI**: "gpt-4o", "gpt-4o-mini", "gpt-4-turbo"
@@ -236,6 +247,7 @@ triage:
 - `model`: "gpt-4o-mini"
 - `max_tokens`: 500
 - `timeout_sec`: 10
+- `health_check_mode`: "full"
 
 ### Deep Triage Configuration
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -72,6 +72,30 @@ docker run -d \
   agentshield/engine:latest
 ```
 
+## Transport Security (TLS)
+
+AgentShield does **not** handle TLS natively. Production deployments that expose AgentShield beyond localhost **must** use a TLS-terminating reverse proxy such as nginx, Caddy, or a cloud load balancer.
+
+### Example: nginx reverse proxy with TLS
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name agentshield.example.com;
+
+    ssl_certificate     /etc/ssl/certs/agentshield.pem;
+    ssl_certificate_key /etc/ssl/private/agentshield.key;
+
+    location / {
+        proxy_pass http://127.0.0.1:8433;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+
+When running behind a reverse proxy, bind AgentShield to `127.0.0.1` (the default) so it is not directly reachable from the network. The engine will log a warning at startup if a non-localhost bind address is detected.
+
 ## Configuration Setup
 
 ### Directory Structure

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"log/slog"
 	"net"
 	"net/netip"
 	"net/url"
@@ -73,14 +74,15 @@ type CorrelationConfig struct {
 
 // TriageConfig holds triage configuration (fast triage — synchronous, in request path)
 type TriageConfig struct {
-	Enabled     bool              `yaml:"enabled"`
-	Provider    string            `yaml:"provider"` // "openai", "anthropic", or "openclaw"
-	Model       string            `yaml:"model"`    // e.g. "gpt-4o-mini", "claude-sonnet-4-20250514"
-	APIKey      string            `yaml:"api_key"`  // env: AGENTSHIELD_TRIAGE_API_KEY
-	BaseURL     string            `yaml:"base_url"` // custom base URL (e.g. https://openrouter.ai/api/v1)
-	MaxTokens   int               `yaml:"max_tokens"`
-	TimeoutSec  int               `yaml:"timeout_sec"`
-	Correlation CorrelationConfig `yaml:"correlation"`
+	Enabled         bool              `yaml:"enabled"`
+	Provider        string            `yaml:"provider"`          // "openai", "anthropic", or "openclaw"
+	Model           string            `yaml:"model"`             // e.g. "gpt-4o-mini", "claude-sonnet-4-20250514"
+	APIKey          string            `yaml:"api_key"`           // env: AGENTSHIELD_TRIAGE_API_KEY
+	BaseURL         string            `yaml:"base_url"`          // custom base URL (e.g. https://openrouter.ai/api/v1)
+	MaxTokens       int               `yaml:"max_tokens"`
+	TimeoutSec      int               `yaml:"timeout_sec"`
+	HealthCheckMode string            `yaml:"health_check_mode"` // "full" (default) or "connectivity"
+	Correlation     CorrelationConfig `yaml:"correlation"`
 }
 
 // DeepTriageConfig holds deep triage configuration (async, OpenClaw sub-agent with tools)
@@ -263,8 +265,11 @@ func validateConfig(cfg *Config) error {
 	}
 
 	// SECURITY: Validate bind address
-	if cfg.Server.Addr == "0.0.0.0" {
-		fmt.Printf("WARNING: Server binding to all interfaces (0.0.0.0). Consider using 127.0.0.1 for localhost only.\n")
+	if IsNonLocalhost(cfg.Server.Addr) {
+		slog.Warn("server binding to a non-localhost address; use a TLS-terminating reverse proxy in production",
+			"addr", cfg.Server.Addr,
+			"recommendation", "deploy behind nginx/Caddy with TLS or bind to 127.0.0.1",
+		)
 	}
 
 	// Validate port range
@@ -335,6 +340,18 @@ func validateIntRange(name string, value, min, max int) error {
 		return fmt.Errorf("%s must be between %d and %d", name, min, max)
 	}
 	return nil
+}
+
+// IsNonLocalhost reports whether addr is NOT a localhost address.
+// It returns true for addresses like "0.0.0.0", "192.168.1.1", or any
+// address that is not "127.0.0.1", "localhost", or "::1".
+func IsNonLocalhost(addr string) bool {
+	switch strings.ToLower(strings.TrimSpace(addr)) {
+	case "127.0.0.1", "localhost", "::1":
+		return false
+	default:
+		return true
+	}
 }
 
 // IsPrivateOrLocalURL checks whether a URL targets a private/local network.

--- a/internal/config/config_security_test.go
+++ b/internal/config/config_security_test.go
@@ -1,0 +1,35 @@
+package config
+
+import "testing"
+
+func TestIsNonLocalhost(t *testing.T) {
+	tests := []struct {
+		addr string
+		want bool
+	}{
+		// Localhost addresses (safe)
+		{"127.0.0.1", false},
+		{"localhost", false},
+		{"::1", false},
+		{"Localhost", false},  // case-insensitive
+		{" 127.0.0.1 ", false}, // trimmed
+
+		// Non-localhost addresses (should warn)
+		{"0.0.0.0", true},
+		{"192.168.1.1", true},
+		{"10.0.0.1", true},
+		{"::", true},
+		{"0.0.0.0", true},
+		{"example.com", true},
+		{"", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.addr, func(t *testing.T) {
+			got := IsNonLocalhost(tt.addr)
+			if got != tt.want {
+				t.Errorf("IsNonLocalhost(%q) = %v, want %v", tt.addr, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -208,38 +209,81 @@ func (e *Engine) loadRuleFile(filePath string) (*LoadedRule, error) {
 	}, nil
 }
 
-// validateRuleRegexComplexity validates regex patterns to prevent ReDoS attacks
+// extractSearchAtoms walks the expression tree and collects all SearchAtom nodes.
+func extractSearchAtoms(expr sigma.Expr) []*sigma.SearchAtom {
+	var atoms []*sigma.SearchAtom
+	switch e := expr.(type) {
+	case *sigma.SearchAtom:
+		atoms = append(atoms, e)
+	case *sigma.AndExpr:
+		for _, x := range e.X {
+			atoms = append(atoms, extractSearchAtoms(x)...)
+		}
+	case *sigma.OrExpr:
+		for _, x := range e.X {
+			atoms = append(atoms, extractSearchAtoms(x)...)
+		}
+	case *sigma.NotExpr:
+		atoms = append(atoms, extractSearchAtoms(e.X)...)
+	case *sigma.NamedExpr:
+		atoms = append(atoms, extractSearchAtoms(e.X)...)
+	}
+	return atoms
+}
+
+// validateRuleRegexComplexity validates regex patterns in |re modified atoms
+// to prevent ReDoS attacks. It walks the parsed detection expression tree
+// rather than relying on string-formatting the rule.
 func (e *Engine) validateRuleRegexComplexity(rule *sigma.Rule) error {
-	// This is a simplified ReDoS protection
-	// In practice, you'd want more sophisticated analysis
-	
-	// Convert rule to string to find potential regex patterns
-	ruleStr := fmt.Sprintf("%+v", rule)
-	
-	// Check for obvious ReDoS patterns
+	if rule.Detection == nil || rule.Detection.Expr == nil {
+		return nil
+	}
+
+	atoms := extractSearchAtoms(rule.Detection.Expr)
+
+	// Known dangerous nested-quantifier patterns.
 	dangerousPatterns := []string{
-		`(.*)*`,           // Nested quantifiers
-		`(.+)+`,           
+		`(.*)*`,
+		`(.+)+`,
 		`(.{0,})*`,
-		`(a|a)*`,          // Alternation with repetition
+		`(a|a)*`,
 		`(a*)*`,
 		`(a+)+`,
 		`(a{0,}){0,}`,
 	}
 
-	for _, pattern := range dangerousPatterns {
-		if strings.Contains(strings.ToLower(ruleStr), pattern) {
-			return fmt.Errorf("potentially dangerous regex pattern detected: %s", pattern)
+	for _, atom := range atoms {
+		hasRe := false
+		for _, mod := range atom.Modifiers {
+			if mod == "re" {
+				hasRe = true
+				break
+			}
+		}
+		if !hasRe {
+			continue
+		}
+
+		for _, pattern := range atom.Patterns {
+			// Check pattern length.
+			if len(pattern) > 1000 {
+				return fmt.Errorf("regex pattern too long (%d chars, max 1000)", len(pattern))
+			}
+
+			// Check for dangerous nested-quantifier patterns.
+			lower := strings.ToLower(pattern)
+			for _, dangerous := range dangerousPatterns {
+				if strings.Contains(lower, dangerous) {
+					return fmt.Errorf("potentially dangerous regex pattern detected: %s", dangerous)
+				}
+			}
+
+			// Verify the pattern compiles (Go's RE2 rejects some pathological patterns).
+			if _, err := regexp.Compile(pattern); err != nil {
+				return fmt.Errorf("invalid regex pattern: %w", err)
+			}
 		}
 	}
-
-	// Check for excessive length (another ReDoS vector)
-	if len(ruleStr) > 10000 { // 10KB limit per rule
-		return fmt.Errorf("rule content too long (%d bytes, max 10KB)", len(ruleStr))
-	}
-
-	// Additional regex validation could be added here
-	// For example, actually parsing regex patterns and analyzing their complexity
 
 	return nil
 }

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -119,40 +119,196 @@ func TestIsPathSafe(t *testing.T) {
 }
 
 func TestValidateRuleRegexComplexity(t *testing.T) {
-	// Create mock rule with potentially dangerous patterns
 	tests := []struct {
-		name        string
-		ruleContent string
-		expectError bool
+		name         string
+		ruleYAML     string
+		wantRejected bool // true means the rule should be rejected (not loaded)
 	}{
 		{
-			name:        "simple rule should pass",
-			ruleContent: "simple rule content",
-			expectError: false,
+			name: "safe regex rule loads successfully",
+			ruleYAML: `
+title: Safe Regex Rule
+id: safe-regex-1
+status: experimental
+logsource:
+  category: test
+detection:
+  selection:
+    field|re: "^https?://[a-zA-Z0-9.]+$"
+  condition: selection
+level: medium
+`,
+			wantRejected: false,
 		},
 		{
-			name:        "nested quantifiers should fail",
-			ruleContent: "contains (.*)*",
-			expectError: true,
+			name: "nested quantifier (.*) star rejected",
+			ruleYAML: `
+title: Evil Nested Star
+id: evil-nested-star
+status: experimental
+logsource:
+  category: test
+detection:
+  selection:
+    field|re: "(.*)*evil"
+  condition: selection
+level: medium
+`,
+			wantRejected: true,
 		},
 		{
-			name:        "plus quantifiers should fail",
-			ruleContent: "contains (.+)+",
-			expectError: true,
+			name: "nested quantifier (.+)+ rejected",
+			ruleYAML: `
+title: Evil Nested Plus
+id: evil-nested-plus
+status: experimental
+logsource:
+  category: test
+detection:
+  selection:
+    field|re: "(.+)+attack"
+  condition: selection
+level: medium
+`,
+			wantRejected: true,
 		},
 		{
-			name:        "very long rule should fail",
-			ruleContent: strings.Repeat("x", 15000),
-			expectError: true,
+			name: "very long regex pattern rejected",
+			ruleYAML: `
+title: Long Regex Rule
+id: long-regex-1
+status: experimental
+logsource:
+  category: test
+detection:
+  selection:
+    field|re: "` + strings.Repeat("a", 1001) + `"
+  condition: selection
+level: medium
+`,
+			wantRejected: true,
+		},
+		{
+			name: "rule without re modifier is unaffected",
+			ruleYAML: `
+title: Normal Contains Rule
+id: normal-contains-1
+status: experimental
+logsource:
+  category: test
+detection:
+  selection:
+    field|contains: "totally fine (.*)*"
+  condition: selection
+level: medium
+`,
+			wantRejected: false,
+		},
+		{
+			name: "valid regex with character class passes",
+			ruleYAML: `
+title: Valid Regex
+id: valid-regex-1
+status: experimental
+logsource:
+  category: test
+detection:
+  selection:
+    field|re: "[0-9]{1,5}\\.[0-9]{1,5}"
+  condition: selection
+level: medium
+`,
+			wantRejected: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Since the actual validation depends on the rule structure,
-			// we'll test the basic length check
-			if len(tt.ruleContent) > 10000 && !tt.expectError {
-				t.Error("Expected error for very long rule content")
+			tmpDir, err := os.MkdirTemp("", "regex_complexity_test")
+			if err != nil {
+				t.Fatalf("creating temp dir: %v", err)
+			}
+			defer os.RemoveAll(tmpDir)
+
+			rulePath := filepath.Join(tmpDir, "rule.yml")
+			if err := os.WriteFile(rulePath, []byte(tt.ruleYAML), 0644); err != nil {
+				t.Fatalf("writing rule file: %v", err)
+			}
+
+			eng, engineErr := NewEngine(tmpDir)
+			if engineErr != nil {
+				t.Fatalf("NewEngine() unexpected error: %v", engineErr)
+			}
+
+			loaded := eng.GetLoadedRules()
+			if tt.wantRejected && len(loaded) != 0 {
+				t.Errorf("expected dangerous rule to be rejected, but %d rules loaded", len(loaded))
+			}
+			if !tt.wantRejected && len(loaded) != 1 {
+				t.Errorf("expected rule to be loaded, but %d rules loaded", len(loaded))
+			}
+		})
+	}
+}
+
+func TestExtractSearchAtoms(t *testing.T) {
+	tests := []struct {
+		name     string
+		expr     sigma.Expr
+		expected int
+	}{
+		{
+			name:     "single SearchAtom",
+			expr:     &sigma.SearchAtom{Field: "f1", Patterns: []string{"v1"}},
+			expected: 1,
+		},
+		{
+			name: "AndExpr with two atoms",
+			expr: &sigma.AndExpr{X: []sigma.Expr{
+				&sigma.SearchAtom{Field: "f1", Patterns: []string{"v1"}},
+				&sigma.SearchAtom{Field: "f2", Patterns: []string{"v2"}},
+			}},
+			expected: 2,
+		},
+		{
+			name: "OrExpr with two atoms",
+			expr: &sigma.OrExpr{X: []sigma.Expr{
+				&sigma.SearchAtom{Field: "f1", Patterns: []string{"v1"}},
+				&sigma.SearchAtom{Field: "f2", Patterns: []string{"v2"}},
+			}},
+			expected: 2,
+		},
+		{
+			name: "NotExpr wrapping atom",
+			expr: &sigma.NotExpr{X: &sigma.SearchAtom{Field: "f1", Patterns: []string{"v1"}}},
+			expected: 1,
+		},
+		{
+			name: "NamedExpr wrapping atom",
+			expr: &sigma.NamedExpr{Name: "selection", X: &sigma.SearchAtom{Field: "f1", Patterns: []string{"v1"}}},
+			expected: 1,
+		},
+		{
+			name: "nested structure",
+			expr: &sigma.NamedExpr{
+				Name: "sel",
+				X: &sigma.AndExpr{X: []sigma.Expr{
+					&sigma.SearchAtom{Field: "f1", Patterns: []string{"v1"}},
+					&sigma.OrExpr{X: []sigma.Expr{
+						&sigma.SearchAtom{Field: "f2", Patterns: []string{"v2"}},
+						&sigma.NotExpr{X: &sigma.SearchAtom{Field: "f3", Patterns: []string{"v3"}}},
+					}},
+				}},
+			},
+			expected: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			atoms := extractSearchAtoms(tt.expr)
+			if len(atoms) != tt.expected {
+				t.Errorf("extractSearchAtoms() returned %d atoms, want %d", len(atoms), tt.expected)
 			}
 		})
 	}

--- a/internal/triage/anthropic.go
+++ b/internal/triage/anthropic.go
@@ -147,9 +147,64 @@ func (p *AnthropicProvider) Triage(ctx context.Context, triageCtx *TriageContext
 	return parseTriageResponse(content, p.Name(), p.config.Model, processingTime)
 }
 
-// HealthCheck performs a health check against the Anthropic API
+// HealthCheck performs a health check against the Anthropic API.
+// When HealthCheckMode is "connectivity", it uses a minimal request (max_tokens=1,
+// single-char prompt) to minimize token cost. Otherwise (default "full"), it uses
+// the standard health check request.
 func (p *AnthropicProvider) HealthCheck(ctx context.Context) error {
-	// Simple health check - make a minimal request to verify API connectivity
+	if p.config.HealthCheckMode == "connectivity" {
+		return p.healthCheckConnectivity(ctx)
+	}
+	return p.healthCheckFull(ctx)
+}
+
+// healthCheckConnectivity validates API key and connectivity with a minimal
+// completion request. Anthropic has no free endpoint, so we minimize cost by
+// using max_tokens=1 and the shortest possible prompt (".").
+func (p *AnthropicProvider) healthCheckConnectivity(ctx context.Context) error {
+	reqBody := AnthropicRequest{
+		Model:     p.config.Model,
+		MaxTokens: 1,
+		Messages: []AnthropicMessage{
+			{
+				Role:    "user",
+				Content: ".",
+			},
+		},
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("marshaling connectivity check request: %w", err)
+	}
+
+	req, err := retryablehttp.NewRequestWithContext(ctx, "POST", p.apiURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("creating connectivity check request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", p.config.APIKey)
+	req.Header.Set("anthropic-version", "2023-06-01")
+	req.Header.Set("User-Agent", "AgentShield/1.0")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("Anthropic connectivity check failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return fmt.Errorf("Anthropic API authentication failed - check API key")
+	}
+	if resp.StatusCode >= 500 {
+		return fmt.Errorf("Anthropic API server error: %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// healthCheckFull makes a standard completion request to verify full API functionality.
+func (p *AnthropicProvider) healthCheckFull(ctx context.Context) error {
 	reqBody := AnthropicRequest{
 		Model:     p.config.Model,
 		MaxTokens: 5,

--- a/internal/triage/openai.go
+++ b/internal/triage/openai.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/agentshield-ai/agentshield/internal/config"
@@ -159,9 +160,46 @@ func (p *OpenAIProvider) Triage(ctx context.Context, triageCtx *TriageContext) (
 	return parseTriageResponse(content, p.Name(), p.config.Model, processingTime)
 }
 
-// HealthCheck performs a health check against the OpenAI API
+// HealthCheck performs a health check against the OpenAI API.
+// When HealthCheckMode is "connectivity", it uses the free /v1/models endpoint.
+// Otherwise (default "full"), it makes a minimal completion request.
 func (p *OpenAIProvider) HealthCheck(ctx context.Context) error {
-	// Simple health check - make a minimal request to verify API connectivity
+	if p.config.HealthCheckMode == "connectivity" {
+		return p.healthCheckConnectivity(ctx)
+	}
+	return p.healthCheckFull(ctx)
+}
+
+// healthCheckConnectivity validates API key and connectivity using the
+// free models list endpoint (GET /v1/models), which costs zero tokens.
+func (p *OpenAIProvider) healthCheckConnectivity(ctx context.Context) error {
+	modelsURL := strings.TrimSuffix(p.apiURL, "/chat/completions") + "/models"
+
+	req, err := retryablehttp.NewRequestWithContext(ctx, "GET", modelsURL, nil)
+	if err != nil {
+		return fmt.Errorf("creating connectivity check request: %w", err)
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", p.config.APIKey))
+	req.Header.Set("User-Agent", "AgentShield/1.0")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("OpenAI connectivity check failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return fmt.Errorf("OpenAI API authentication failed - check API key")
+	}
+	if resp.StatusCode >= 500 {
+		return fmt.Errorf("OpenAI API server error: %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// healthCheckFull makes a minimal completion request to verify full API functionality.
+func (p *OpenAIProvider) healthCheckFull(ctx context.Context) error {
 	reqBody := OpenAIRequest{
 		Model: p.config.Model,
 		Messages: []OpenAIMessage{

--- a/internal/triage/triage_test.go
+++ b/internal/triage/triage_test.go
@@ -1870,6 +1870,267 @@ func TestScoreCorrelationTestContext(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Tests for HealthCheck connectivity mode
+// ---------------------------------------------------------------------------
+
+func TestHealthCheckConnectivityMode(t *testing.T) {
+	t.Run("OpenAI connectivity mode uses models endpoint", func(t *testing.T) {
+		var requestedPath string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestedPath = r.URL.Path
+			if r.Header.Get("Authorization") == "Bearer test-key" {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"data":[{"id":"gpt-4o-mini"}]}`))
+			} else {
+				w.WriteHeader(http.StatusUnauthorized)
+			}
+		}))
+		defer server.Close()
+
+		cfg := &config.TriageConfig{
+			APIKey:          "test-key",
+			Model:           "gpt-4o-mini",
+			TimeoutSec:      10,
+			HealthCheckMode: "connectivity",
+		}
+
+		provider := &OpenAIProvider{
+			config: cfg,
+			client: createLocalHTTPClient(10 * time.Second),
+			apiURL: server.URL + "/chat/completions",
+		}
+
+		err := provider.HealthCheck(context.Background())
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		if requestedPath != "/models" {
+			t.Errorf("expected /models path, got %s", requestedPath)
+		}
+	})
+
+	t.Run("OpenAI connectivity mode auth failure", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		defer server.Close()
+
+		cfg := &config.TriageConfig{
+			APIKey:          "bad-key",
+			Model:           "gpt-4o-mini",
+			TimeoutSec:      10,
+			HealthCheckMode: "connectivity",
+		}
+
+		provider := &OpenAIProvider{
+			config: cfg,
+			client: createLocalHTTPClient(10 * time.Second),
+			apiURL: server.URL + "/chat/completions",
+		}
+
+		err := provider.HealthCheck(context.Background())
+		if err == nil {
+			t.Error("expected error for auth failure")
+		}
+		if !contains(err.Error(), "authentication failed") {
+			t.Errorf("expected auth error, got: %v", err)
+		}
+	})
+
+	t.Run("OpenAI connectivity mode server error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer server.Close()
+
+		cfg := &config.TriageConfig{
+			APIKey:          "test-key",
+			Model:           "gpt-4o-mini",
+			TimeoutSec:      10,
+			HealthCheckMode: "connectivity",
+		}
+
+		provider := &OpenAIProvider{
+			config: cfg,
+			client: createLocalHTTPClient(10 * time.Second),
+			apiURL: server.URL + "/chat/completions",
+		}
+
+		err := provider.HealthCheck(context.Background())
+		if err == nil {
+			t.Error("expected error for server error")
+		}
+	})
+
+	t.Run("OpenAI default mode still uses completion endpoint", func(t *testing.T) {
+		var requestedPath string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestedPath = r.URL.Path
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"choices":[{"message":{"content":"Test"}}]}`))
+		}))
+		defer server.Close()
+
+		cfg := &config.TriageConfig{
+			APIKey:     "test-key",
+			Model:      "gpt-4o-mini",
+			TimeoutSec: 10,
+			// HealthCheckMode left empty = "full" mode
+		}
+
+		provider := &OpenAIProvider{
+			config: cfg,
+			client: createLocalHTTPClient(10 * time.Second),
+			apiURL: server.URL + "/chat/completions",
+		}
+
+		err := provider.HealthCheck(context.Background())
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		if requestedPath != "/chat/completions" {
+			t.Errorf("expected /chat/completions path for full mode, got %s", requestedPath)
+		}
+	})
+
+	t.Run("Anthropic connectivity mode uses minimal request", func(t *testing.T) {
+		var receivedBody AnthropicRequest
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			json.NewDecoder(r.Body).Decode(&receivedBody)
+			if r.Header.Get("x-api-key") == "test-key" {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"content":[{"type":"text","text":"."}]}`))
+			} else {
+				w.WriteHeader(http.StatusUnauthorized)
+			}
+		}))
+		defer server.Close()
+
+		cfg := &config.TriageConfig{
+			APIKey:          "test-key",
+			Model:           "claude-sonnet-4-20250514",
+			TimeoutSec:      10,
+			HealthCheckMode: "connectivity",
+		}
+
+		provider := &AnthropicProvider{
+			config: cfg,
+			client: createLocalHTTPClient(10 * time.Second),
+			apiURL: server.URL,
+		}
+
+		err := provider.HealthCheck(context.Background())
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		if receivedBody.MaxTokens != 1 {
+			t.Errorf("expected max_tokens=1 for connectivity mode, got %d", receivedBody.MaxTokens)
+		}
+		if len(receivedBody.Messages) != 1 || receivedBody.Messages[0].Content != "." {
+			t.Errorf("expected minimal prompt '.' for connectivity mode, got %+v", receivedBody.Messages)
+		}
+	})
+
+	t.Run("Anthropic connectivity mode auth failure", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		defer server.Close()
+
+		cfg := &config.TriageConfig{
+			APIKey:          "bad-key",
+			Model:           "claude-sonnet-4-20250514",
+			TimeoutSec:      10,
+			HealthCheckMode: "connectivity",
+		}
+
+		provider := &AnthropicProvider{
+			config: cfg,
+			client: createLocalHTTPClient(10 * time.Second),
+			apiURL: server.URL,
+		}
+
+		err := provider.HealthCheck(context.Background())
+		if err == nil {
+			t.Error("expected error for auth failure")
+		}
+		if !contains(err.Error(), "authentication failed") {
+			t.Errorf("expected auth error, got: %v", err)
+		}
+	})
+
+	t.Run("Anthropic default mode uses standard request", func(t *testing.T) {
+		var receivedBody AnthropicRequest
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			json.NewDecoder(r.Body).Decode(&receivedBody)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"content":[{"type":"text","text":"Test"}]}`))
+		}))
+		defer server.Close()
+
+		cfg := &config.TriageConfig{
+			APIKey:     "test-key",
+			Model:      "claude-sonnet-4-20250514",
+			TimeoutSec: 10,
+			// HealthCheckMode left empty = "full" mode
+		}
+
+		provider := &AnthropicProvider{
+			config: cfg,
+			client: createLocalHTTPClient(10 * time.Second),
+			apiURL: server.URL,
+		}
+
+		err := provider.HealthCheck(context.Background())
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		if receivedBody.MaxTokens != 5 {
+			t.Errorf("expected max_tokens=5 for full mode, got %d", receivedBody.MaxTokens)
+		}
+		if len(receivedBody.Messages) != 1 || receivedBody.Messages[0].Content != "Test" {
+			t.Errorf("expected 'Test' prompt for full mode, got %+v", receivedBody.Messages)
+		}
+	})
+
+	t.Run("backward compat empty HealthCheckMode equals full", func(t *testing.T) {
+		var requestedMethod string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestedMethod = r.Method
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"choices":[{"message":{"content":"Test"}}]}`))
+		}))
+		defer server.Close()
+
+		cfg := &config.TriageConfig{
+			APIKey:          "test-key",
+			Model:           "gpt-4o-mini",
+			TimeoutSec:      10,
+			HealthCheckMode: "", // Explicitly empty
+		}
+
+		provider := &OpenAIProvider{
+			config: cfg,
+			client: createLocalHTTPClient(10 * time.Second),
+			apiURL: server.URL + "/chat/completions",
+		}
+
+		err := provider.HealthCheck(context.Background())
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		if requestedMethod != "POST" {
+			t.Errorf("expected POST for full mode, got %s", requestedMethod)
+		}
+	})
+}
+
 // Helper function
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) &&


### PR DESCRIPTION
## Summary
Greptile remediation pass 1 for high-confidence findings from baseline review PR #5.

## Fixed
1. **TLS / transport hardening clarity**
   - Added explicit TLS guidance in `docs/deployment.md` (reverse proxy requirement + nginx example)
   - Added TLS note in `docs/configuration.md`
   - Startup warning now uses structured logging and triggers for any non-localhost bind (`IsNonLocalhost` helper + tests)

2. **ReDoS guard improvements**
   - Reworked regex complexity validation to walk parsed Sigma expression tree (`extractSearchAtoms`) instead of stringifying rules
   - Validate only `|re` atoms with:
     - pattern length cap
     - dangerous nested-quantifier checks
     - compile-time regex sanity check
   - Added tests for safe/unsafe/edge cases

3. **Health-check token-cost controls**
   - Added `triage.health_check_mode` config (`full` | `connectivity`)
   - OpenAI connectivity mode uses `/v1/models` check (no completion)
   - Anthropic connectivity mode uses minimal request path
   - Added provider tests + docs updates

## Deferred (tracked for later pass)
- Native TLS listener support in-process (currently reverse-proxy TLS model)
- Broader operational scaling work (e.g., DB backend changes)

## Validation
- `go test ./...` passes locally
