### PR TITLE
feat: add require_approval action for graduated response

### DIFF
--- a/cmd/agentshieldbench/main.go
+++ b/cmd/agentshieldbench/main.go
@@ -47,7 +47,7 @@ type Event struct {
 
 // Expected is the expected outcome.
 type Expected struct {
-	Action           string   `yaml:"action"`                      // ALLOW, BLOCK, LOG
+	Action           string   `yaml:"action"`                      // ALLOW, BLOCK, LOG, REQUIRE_APPROVAL
 	MustTriggerRules []string `yaml:"must_trigger_rules,omitempty"` // rule IDs
 	MustNotTrigger   []string `yaml:"must_not_trigger,omitempty"`   // rule IDs that must NOT fire
 }
@@ -142,9 +142,10 @@ func computeMetrics(suiteName string, results []ResultLine, testcases map[string
 			}
 		} else {
 			expected := strings.ToUpper(r.ExpectedAction)
-			if expected == "BLOCK" {
+			if expected == "BLOCK" || expected == "REQUIRE_APPROVAL" {
 				adversarialTotal++
-				if strings.ToUpper(r.ActualAction) == "BLOCK" {
+				actual := strings.ToUpper(r.ActualAction)
+				if actual == "BLOCK" || actual == "REQUIRE_APPROVAL" {
 					adversarialBlocked++
 				} else {
 					adversarialEvaded++

--- a/internal/evaluate/evaluate.go
+++ b/internal/evaluate/evaluate.go
@@ -149,7 +149,7 @@ func (e *Evaluator) determineEffectiveMode() config.EvaluationMode {
 // Severity-to-action mapping (enforce mode):
 //   - critical/high -> block
 //   - medium        -> require_approval
-//   - low           -> log
+//   - low/none      -> allow
 //
 // Mode interactions:
 //   - audit:  require_approval downgrades to log (audit never blocks or asks)

--- a/internal/evaluate/evaluate.go
+++ b/internal/evaluate/evaluate.go
@@ -71,13 +71,15 @@ func (e *Evaluator) Evaluate(req *models.EvaluationRequest) (*EvaluationResponse
 	alerts := e.engine.Evaluate(req.Fields)
 
 	// Count severity levels for decision making
-	var criticalCount, highCount int
+	var criticalCount, highCount, mediumCount int
 	for _, result := range alerts {
 		switch result.Severity {
 		case engine.SeverityCritical:
 			criticalCount++
 		case engine.SeverityHigh:
 			highCount++
+		case engine.SeverityMedium:
+			mediumCount++
 		}
 	}
 
@@ -99,10 +101,10 @@ func (e *Evaluator) Evaluate(req *models.EvaluationRequest) (*EvaluationResponse
 	var overridable bool
 	if len(triageResults) > 0 {
 		// Use triage-informed decision
-		action, overridable = e.incorporateTriageResults(effectiveMode, criticalCount, highCount, triageResults)
+		action, overridable = e.incorporateTriageResults(effectiveMode, criticalCount, highCount, mediumCount, triageResults)
 	} else {
 		// Fallback to rule-only decision if triage is disabled or failed
-		action, overridable = e.determineAction(effectiveMode, criticalCount, highCount)
+		action, overridable = e.determineAction(effectiveMode, criticalCount, highCount, mediumCount)
 	}
 
 	// Build response once
@@ -143,18 +145,28 @@ func (e *Evaluator) determineEffectiveMode() config.EvaluationMode {
 	return e.defaultMode
 }
 
-// determineAction determines what action to take based on mode and alert severity
-func (e *Evaluator) determineAction(mode config.EvaluationMode, criticalCount, highCount int) (models.Action, bool) {
+// determineAction determines what action to take based on mode and alert severity.
+// Severity-to-action mapping (enforce mode):
+//   - critical/high -> block
+//   - medium        -> require_approval
+//   - low           -> log
+//
+// Mode interactions:
+//   - audit:  require_approval downgrades to log (audit never blocks or asks)
+//   - shadow: require_approval downgrades to allow (shadow is silent)
+func (e *Evaluator) determineAction(mode config.EvaluationMode, criticalCount, highCount, mediumCount int) (models.Action, bool) {
 	switch mode {
 	case config.ModeEnforce:
-		// Block on critical or high severity alerts
 		if criticalCount > 0 || highCount > 0 {
 			return models.ActionBlock, true // Overridable in enforce mode
+		}
+		if mediumCount > 0 {
+			return models.ActionRequireApproval, true
 		}
 		return models.ActionAllow, false
 
 	case config.ModeAudit:
-		// Log everything, never block
+		// Log everything, never block or require approval
 		return models.ActionLog, false
 
 	case config.ModeShadow:
@@ -166,22 +178,25 @@ func (e *Evaluator) determineAction(mode config.EvaluationMode, criticalCount, h
 		if criticalCount > 0 || highCount > 0 {
 			return models.ActionBlock, true
 		}
+		if mediumCount > 0 {
+			return models.ActionRequireApproval, true
+		}
 		return models.ActionAllow, false
 	}
 }
 
 // incorporateTriageResults adjusts the action based on triage analysis
-func (e *Evaluator) incorporateTriageResults(mode config.EvaluationMode, criticalCount, highCount int, triageResults []triage.TriageResult) (models.Action, bool) {
+func (e *Evaluator) incorporateTriageResults(mode config.EvaluationMode, criticalCount, highCount, mediumCount int, triageResults []triage.TriageResult) (models.Action, bool) {
 	// Start with rule-only decision
-	baseAction, baseOverridable := e.determineAction(mode, criticalCount, highCount)
+	baseAction, baseOverridable := e.determineAction(mode, criticalCount, highCount, mediumCount)
 
 	// In audit and shadow modes, triage doesn't change the action
 	if mode != config.ModeEnforce {
 		return baseAction, baseOverridable
 	}
 
-	// Security-critical: triage must never downgrade a block in enforce mode.
-	if baseAction == models.ActionBlock {
+	// Security-critical: triage must never downgrade a block or require_approval in enforce mode.
+	if baseAction == models.ActionBlock || baseAction == models.ActionRequireApproval {
 		return baseAction, baseOverridable
 	}
 
@@ -192,11 +207,12 @@ func (e *Evaluator) incorporateTriageResults(mode config.EvaluationMode, critica
 func GetModeInfo() map[string]interface{} {
 	return map[string]interface{}{
 		"modes": map[string]string{
-			"enforce": "Block on critical/high alerts, allow others",
-			"audit":   "Log all alerts, never block",
+			"enforce": "Block on critical/high, require approval on medium, allow others",
+			"audit":   "Log all alerts, never block or require approval",
 			"shadow":  "Allow everything silently, evaluate in background",
 		},
 		"downgrade_policy":    "Mode is server-side only (no client override)",
 		"blocking_severities": []string{"critical", "high"},
+		"approval_severities": []string{"medium"},
 	}
 }

--- a/internal/evaluate/evaluate_edge_cases_test.go
+++ b/internal/evaluate/evaluate_edge_cases_test.go
@@ -101,14 +101,20 @@ func TestDetermineActionEdgeCases(t *testing.T) {
 	t.Run("unknown mode defaults to enforce behavior", func(t *testing.T) {
 		unknownMode := config.EvaluationMode("unknown")
 
-		// With alerts - should block like enforce mode
-		action, overridable := evaluator.determineAction(unknownMode, 1, 0)
+		// With critical alerts - should block like enforce mode
+		action, overridable := evaluator.determineAction(unknownMode, 1, 0, 0)
 		if action != models.ActionBlock || !overridable {
-			t.Errorf("Unknown mode with alerts: expected block/overridable, got %s/%t", action, overridable)
+			t.Errorf("Unknown mode with critical alerts: expected block/overridable, got %s/%t", action, overridable)
+		}
+
+		// With medium alerts - should require approval like enforce mode
+		action, overridable = evaluator.determineAction(unknownMode, 0, 0, 1)
+		if action != models.ActionRequireApproval || !overridable {
+			t.Errorf("Unknown mode with medium alerts: expected require_approval/overridable, got %s/%t", action, overridable)
 		}
 
 		// Without alerts - should allow like enforce mode
-		action, overridable = evaluator.determineAction(unknownMode, 0, 0)
+		action, overridable = evaluator.determineAction(unknownMode, 0, 0, 0)
 		if action != models.ActionAllow || overridable {
 			t.Errorf("Unknown mode without alerts: expected allow/not overridable, got %s/%t", action, overridable)
 		}
@@ -116,7 +122,7 @@ func TestDetermineActionEdgeCases(t *testing.T) {
 
 	t.Run("large counts", func(t *testing.T) {
 		// Test with very large counts
-		action, overridable := evaluator.determineAction(config.ModeEnforce, 999999, 888888)
+		action, overridable := evaluator.determineAction(config.ModeEnforce, 999999, 888888, 777777)
 		if action != models.ActionBlock || !overridable {
 			t.Errorf("Large counts: expected block/overridable, got %s/%t", action, overridable)
 		}
@@ -124,21 +130,23 @@ func TestDetermineActionEdgeCases(t *testing.T) {
 
 	t.Run("zero vs non-zero combinations", func(t *testing.T) {
 		testCases := []struct {
-			critical, high int
-			expectBlock    bool
+			critical, high, medium int
+			expectAction           models.Action
 		}{
-			{0, 0, false},
-			{1, 0, true},
-			{0, 1, true},
-			{1, 1, true},
+			{0, 0, 0, models.ActionAllow},
+			{1, 0, 0, models.ActionBlock},
+			{0, 1, 0, models.ActionBlock},
+			{1, 1, 0, models.ActionBlock},
+			{0, 0, 1, models.ActionRequireApproval},
+			{1, 0, 1, models.ActionBlock}, // critical takes precedence
+			{0, 1, 1, models.ActionBlock}, // high takes precedence
 		}
 
 		for _, tc := range testCases {
-			action, _ := evaluator.determineAction(config.ModeEnforce, tc.critical, tc.high)
-			actualBlock := action == models.ActionBlock
-			if actualBlock != tc.expectBlock {
-				t.Errorf("Critical=%d, High=%d: expected block=%t, got block=%t",
-					tc.critical, tc.high, tc.expectBlock, actualBlock)
+			action, _ := evaluator.determineAction(config.ModeEnforce, tc.critical, tc.high, tc.medium)
+			if action != tc.expectAction {
+				t.Errorf("Critical=%d, High=%d, Medium=%d: expected %s, got %s",
+					tc.critical, tc.high, tc.medium, tc.expectAction, action)
 			}
 		}
 	})
@@ -150,7 +158,7 @@ func TestIncorporateTriageResultsEdgeCases(t *testing.T) {
 
 	t.Run("empty triage results", func(t *testing.T) {
 		var emptyResults []triage.TriageResult
-		action, overridable := evaluator.incorporateTriageResults(config.ModeEnforce, 1, 0, emptyResults)
+		action, overridable := evaluator.incorporateTriageResults(config.ModeEnforce, 1, 0, 0, emptyResults)
 
 		// Should default to rule-only decision (block for critical)
 		if action != models.ActionBlock || !overridable {
@@ -165,7 +173,7 @@ func TestIncorporateTriageResultsEdgeCases(t *testing.T) {
 			{Verdict: "", Confidence: 0.7},
 		}
 
-		action, overridable := evaluator.incorporateTriageResults(config.ModeEnforce, 1, 0, triageResults)
+		action, overridable := evaluator.incorporateTriageResults(config.ModeEnforce, 1, 0, 0, triageResults)
 
 		// Unknown verdicts shouldn't count as allow or block, so should stick with original decision
 		if action != models.ActionBlock || !overridable {
@@ -179,7 +187,7 @@ func TestIncorporateTriageResultsEdgeCases(t *testing.T) {
 			{Verdict: "allow", Confidence: 0.8},
 		}
 
-		action, overridable := evaluator.incorporateTriageResults(config.ModeEnforce, 1, 0, triageResults)
+		action, overridable := evaluator.incorporateTriageResults(config.ModeEnforce, 1, 0, 0, triageResults)
 
 		if action != models.ActionBlock || !overridable {
 			t.Errorf("Investigate verdict: expected block/overridable, got %s/%t", action, overridable)
@@ -192,7 +200,7 @@ func TestIncorporateTriageResultsEdgeCases(t *testing.T) {
 			{Verdict: "block", Confidence: 0.8},
 		}
 
-		action, overridable := evaluator.incorporateTriageResults(config.ModeEnforce, 1, 0, triageResults)
+		action, overridable := evaluator.incorporateTriageResults(config.ModeEnforce, 1, 0, 0, triageResults)
 
 		// Tie should default to original decision (block)
 		if action != models.ActionBlock || !overridable {
@@ -206,7 +214,7 @@ func TestIncorporateTriageResultsEdgeCases(t *testing.T) {
 			{Verdict: "allow", Confidence: 0.6}, // Low confidence
 		}
 
-		action, overridable := evaluator.incorporateTriageResults(config.ModeEnforce, 1, 0, triageResults)
+		action, overridable := evaluator.incorporateTriageResults(config.ModeEnforce, 1, 0, 0, triageResults)
 
 		// Low confidence allows shouldn't override block decision
 		if action != models.ActionBlock || !overridable {
@@ -220,7 +228,7 @@ func TestIncorporateTriageResultsEdgeCases(t *testing.T) {
 			{Verdict: "allow", Confidence: 0.7}, // Exactly at threshold
 		}
 
-		action, _ := evaluator.incorporateTriageResults(config.ModeEnforce, 1, 0, triageResults)
+		action, _ := evaluator.incorporateTriageResults(config.ModeEnforce, 1, 0, 0, triageResults)
 
 		// Should NOT override since 0.7 is not > 0.7
 		if action != models.ActionBlock {
@@ -229,7 +237,7 @@ func TestIncorporateTriageResultsEdgeCases(t *testing.T) {
 
 		// Test just above threshold
 		triageResults[0].Confidence = 0.71
-		action, _ = evaluator.incorporateTriageResults(config.ModeEnforce, 1, 0, triageResults)
+		action, _ = evaluator.incorporateTriageResults(config.ModeEnforce, 1, 0, 0, triageResults)
 
 		// Should still block: triage can no longer downgrade in enforce mode
 		if action != models.ActionBlock {
@@ -246,10 +254,23 @@ func TestIncorporateTriageResultsEdgeCases(t *testing.T) {
 			{Verdict: "allow", Confidence: 0.5},  // Low confidence allow (doesn't count)
 		}
 
-		action, overridable := evaluator.incorporateTriageResults(config.ModeEnforce, 1, 0, triageResults)
+		action, overridable := evaluator.incorporateTriageResults(config.ModeEnforce, 1, 0, 0, triageResults)
 
 		if action != models.ActionBlock || !overridable {
 			t.Errorf("Complex scenario: expected block/overridable, got %s/%t", action, overridable)
+		}
+	})
+
+	t.Run("medium severity with triage preserves require_approval", func(t *testing.T) {
+		triageResults := []triage.TriageResult{
+			{Verdict: "allow", Confidence: 0.9},
+		}
+
+		action, overridable := evaluator.incorporateTriageResults(config.ModeEnforce, 0, 0, 1, triageResults)
+
+		// Triage must not downgrade require_approval in enforce mode
+		if action != models.ActionRequireApproval || !overridable {
+			t.Errorf("Medium with triage: expected require_approval/overridable, got %s/%t", action, overridable)
 		}
 	})
 }

--- a/internal/evaluate/evaluate_test.go
+++ b/internal/evaluate/evaluate_test.go
@@ -45,6 +45,7 @@ func TestDetermineAction(t *testing.T) {
 		mode                config.EvaluationMode
 		criticalCount       int
 		highCount           int
+		mediumCount         int
 		expectedAction      models.Action
 		expectedOverridable bool
 	}{
@@ -53,6 +54,7 @@ func TestDetermineAction(t *testing.T) {
 			mode:                config.ModeEnforce,
 			criticalCount:       1,
 			highCount:           0,
+			mediumCount:         0,
 			expectedAction:      models.ActionBlock,
 			expectedOverridable: true,
 		},
@@ -61,6 +63,7 @@ func TestDetermineAction(t *testing.T) {
 			mode:                config.ModeEnforce,
 			criticalCount:       0,
 			highCount:           1,
+			mediumCount:         0,
 			expectedAction:      models.ActionBlock,
 			expectedOverridable: true,
 		},
@@ -69,22 +72,70 @@ func TestDetermineAction(t *testing.T) {
 			mode:                config.ModeEnforce,
 			criticalCount:       0,
 			highCount:           0,
+			mediumCount:         0,
 			expectedAction:      models.ActionAllow,
 			expectedOverridable: false,
 		},
 		{
-			name:                "audit mode always logs",
+			name:                "enforce mode with medium alert requires approval",
+			mode:                config.ModeEnforce,
+			criticalCount:       0,
+			highCount:           0,
+			mediumCount:         1,
+			expectedAction:      models.ActionRequireApproval,
+			expectedOverridable: true,
+		},
+		{
+			name:                "enforce mode critical takes precedence over medium",
+			mode:                config.ModeEnforce,
+			criticalCount:       1,
+			highCount:           0,
+			mediumCount:         3,
+			expectedAction:      models.ActionBlock,
+			expectedOverridable: true,
+		},
+		{
+			name:                "enforce mode high takes precedence over medium",
+			mode:                config.ModeEnforce,
+			criticalCount:       0,
+			highCount:           1,
+			mediumCount:         5,
+			expectedAction:      models.ActionBlock,
+			expectedOverridable: true,
+		},
+		{
+			name:                "audit mode always logs even with medium",
 			mode:                config.ModeAudit,
 			criticalCount:       5,
 			highCount:           3,
+			mediumCount:         2,
 			expectedAction:      models.ActionLog,
 			expectedOverridable: false,
 		},
 		{
-			name:                "shadow mode always allows",
+			name:                "audit mode logs on medium only",
+			mode:                config.ModeAudit,
+			criticalCount:       0,
+			highCount:           0,
+			mediumCount:         1,
+			expectedAction:      models.ActionLog,
+			expectedOverridable: false,
+		},
+		{
+			name:                "shadow mode always allows even with medium",
 			mode:                config.ModeShadow,
 			criticalCount:       5,
 			highCount:           3,
+			mediumCount:         2,
+			expectedAction:      models.ActionAllow,
+			expectedOverridable: false,
+		},
+		{
+			name:                "shadow mode allows on medium only",
+			mode:                config.ModeShadow,
+			criticalCount:       0,
+			highCount:           0,
+			mediumCount:         1,
 			expectedAction:      models.ActionAllow,
 			expectedOverridable: false,
 		},
@@ -94,7 +145,7 @@ func TestDetermineAction(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			evaluator := &Evaluator{}
 
-			action, overridable := evaluator.determineAction(tt.mode, tt.criticalCount, tt.highCount)
+			action, overridable := evaluator.determineAction(tt.mode, tt.criticalCount, tt.highCount, tt.mediumCount)
 
 			if action != tt.expectedAction {
 				t.Errorf("determineAction() action = %s, want %s", action, tt.expectedAction)
@@ -164,6 +215,48 @@ func TestEvaluate(t *testing.T) {
 			expectedAction: models.ActionAllow,
 			expectedAlerts: 1,
 		},
+		{
+			name: "matched medium severity requires approval in enforce mode",
+			mockResults: []engine.RuleResult{
+				{
+					RuleID:   "test-rule-medium",
+					RuleName: "Medium Severity Rule",
+					Severity: engine.SeverityMedium,
+					Matched:  true,
+				},
+			},
+			defaultMode:    config.ModeEnforce,
+			expectedAction: models.ActionRequireApproval,
+			expectedAlerts: 1,
+		},
+		{
+			name: "matched medium severity logs in audit mode",
+			mockResults: []engine.RuleResult{
+				{
+					RuleID:   "test-rule-medium",
+					RuleName: "Medium Severity Rule",
+					Severity: engine.SeverityMedium,
+					Matched:  true,
+				},
+			},
+			defaultMode:    config.ModeAudit,
+			expectedAction: models.ActionLog,
+			expectedAlerts: 1,
+		},
+		{
+			name: "matched medium severity allows in shadow mode",
+			mockResults: []engine.RuleResult{
+				{
+					RuleID:   "test-rule-medium",
+					RuleName: "Medium Severity Rule",
+					Severity: engine.SeverityMedium,
+					Matched:  true,
+				},
+			},
+			defaultMode:    config.ModeShadow,
+			expectedAction: models.ActionAllow,
+			expectedAlerts: 1,
+		},
 		// client mode override removed: server-side mode only
 	}
 
@@ -213,7 +306,7 @@ func TestGetModeInfo(t *testing.T) {
 	info := GetModeInfo()
 
 	// Check that all expected keys exist
-	expectedKeys := []string{"modes", "downgrade_policy", "blocking_severities"}
+	expectedKeys := []string{"modes", "downgrade_policy", "blocking_severities", "approval_severities"}
 	for _, key := range expectedKeys {
 		if _, exists := info[key]; !exists {
 			t.Errorf("GetModeInfo() missing key: %s", key)

--- a/internal/evaluate/evaluate_triage_test.go
+++ b/internal/evaluate/evaluate_triage_test.go
@@ -211,6 +211,7 @@ func TestIncorporateTriageResults(t *testing.T) {
 		mode                config.EvaluationMode
 		criticalCount       int
 		highCount           int
+		mediumCount         int
 		triageResults       []triage.TriageResult
 		expectedAction      models.Action
 		expectedOverridable bool
@@ -220,6 +221,7 @@ func TestIncorporateTriageResults(t *testing.T) {
 			mode:          config.ModeEnforce,
 			criticalCount: 0,
 			highCount:     1,
+			mediumCount:   0,
 			triageResults: []triage.TriageResult{
 				{Verdict: "allow", Confidence: 0.9},
 			},
@@ -231,6 +233,7 @@ func TestIncorporateTriageResults(t *testing.T) {
 			mode:          config.ModeEnforce,
 			criticalCount: 0,
 			highCount:     2,
+			mediumCount:   0,
 			triageResults: []triage.TriageResult{
 				{Verdict: "allow", Confidence: 0.8},
 				{Verdict: "allow", Confidence: 0.9},
@@ -244,6 +247,7 @@ func TestIncorporateTriageResults(t *testing.T) {
 			mode:          config.ModeEnforce,
 			criticalCount: 1,
 			highCount:     0,
+			mediumCount:   0,
 			triageResults: []triage.TriageResult{
 				{Verdict: "block", Confidence: 0.9},
 				{Verdict: "allow", Confidence: 0.6},
@@ -256,6 +260,7 @@ func TestIncorporateTriageResults(t *testing.T) {
 			mode:          config.ModeAudit,
 			criticalCount: 1,
 			highCount:     1,
+			mediumCount:   0,
 			triageResults: []triage.TriageResult{
 				{Verdict: "allow", Confidence: 0.95},
 			},
@@ -267,6 +272,7 @@ func TestIncorporateTriageResults(t *testing.T) {
 			mode:          config.ModeShadow,
 			criticalCount: 1,
 			highCount:     1,
+			mediumCount:   0,
 			triageResults: []triage.TriageResult{
 				{Verdict: "block", Confidence: 0.95},
 			},
@@ -278,11 +284,48 @@ func TestIncorporateTriageResults(t *testing.T) {
 			mode:          config.ModeEnforce,
 			criticalCount: 0,
 			highCount:     1,
+			mediumCount:   0,
 			triageResults: []triage.TriageResult{
 				{Verdict: "allow", Confidence: 0.5}, // Low confidence
 			},
 			expectedAction:      models.ActionBlock,
 			expectedOverridable: true,
+		},
+		{
+			name:          "Enforce mode - medium severity with triage preserves require_approval",
+			mode:          config.ModeEnforce,
+			criticalCount: 0,
+			highCount:     0,
+			mediumCount:   1,
+			triageResults: []triage.TriageResult{
+				{Verdict: "allow", Confidence: 0.9},
+			},
+			expectedAction:      models.ActionRequireApproval,
+			expectedOverridable: true,
+		},
+		{
+			name:          "Audit mode - medium severity with triage downgrades to log",
+			mode:          config.ModeAudit,
+			criticalCount: 0,
+			highCount:     0,
+			mediumCount:   1,
+			triageResults: []triage.TriageResult{
+				{Verdict: "allow", Confidence: 0.9},
+			},
+			expectedAction:      models.ActionLog,
+			expectedOverridable: false,
+		},
+		{
+			name:          "Shadow mode - medium severity with triage downgrades to allow",
+			mode:          config.ModeShadow,
+			criticalCount: 0,
+			highCount:     0,
+			mediumCount:   1,
+			triageResults: []triage.TriageResult{
+				{Verdict: "allow", Confidence: 0.9},
+			},
+			expectedAction:      models.ActionAllow,
+			expectedOverridable: false,
 		},
 	}
 
@@ -292,6 +335,7 @@ func TestIncorporateTriageResults(t *testing.T) {
 				test.mode,
 				test.criticalCount,
 				test.highCount,
+				test.mediumCount,
 				test.triageResults,
 			)
 

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -18,7 +18,8 @@ type EvaluationRequest struct {
 type Action string
 
 const (
-	ActionAllow Action = "allow"
-	ActionBlock Action = "block"
-	ActionLog   Action = "log"
+	ActionAllow           Action = "allow"
+	ActionBlock           Action = "block"
+	ActionLog             Action = "log"
+	ActionRequireApproval Action = "require_approval"
 )

--- a/plugins/openclaw/src/client.ts
+++ b/plugins/openclaw/src/client.ts
@@ -15,7 +15,7 @@ type Logger = {
 
 const CONTRACT_VERSION = "1.0.0";
 
-const VALID_ACTIONS = new Set(["allow", "block", "log"]);
+const VALID_ACTIONS = new Set(["allow", "block", "log", "require_approval"]);
 
 /**
  * HTTP client for communicating with the AgentShield real-time receiver.

--- a/plugins/openclaw/src/types.ts
+++ b/plugins/openclaw/src/types.ts
@@ -52,7 +52,7 @@ export type Alert = {
 
 /** Evaluation response payload (contract Section 2.2). */
 export type EvaluationResponse = {
-  action: "allow" | "block" | "log";
+  action: "allow" | "block" | "log" | "require_approval";
   event_id: string;
   alerts?: Array<Alert>;
   reason?: string;


### PR DESCRIPTION
## Summary

- Adds `require_approval` as a third action type alongside `allow` and `block`, enabling agent platforms to prompt users before proceeding with medium-severity alerts
- Maps severity to action: critical/high → block, medium → require_approval, low → allow
- Mode-aware downgrades: audit → log, shadow → allow, enforce → passed through to client
- Updates OpenClaw plugin types and benchmark harness to support the new action

## Motivation

Comparative analysis with [Avast Sage](https://github.com/avast/sage) identified that a graduated response model (`allow`/`ask`/`deny`) is more nuanced than a binary `allow`/`block`. This bridges that gap while preserving AgentShield's existing mode semantics.

## Changes

| File | Change |
|---|---|
| `internal/models/models.go` | `ActionRequireApproval` constant |
| `internal/evaluate/evaluate.go` | Severity-to-action mapping, mode downgrades, triage interaction |
| `plugins/openclaw/src/types.ts` | Action union type |
| `plugins/openclaw/src/client.ts` | VALID_ACTIONS set |
| `cmd/agentshieldbench/main.go` | REQUIRE_APPROVAL as valid expected action |
| `internal/evaluate/*_test.go` | 13 new test cases |

## Test plan

- [x] 39/39 Go evaluate tests pass
- [x] 60/60 TypeScript plugin tests pass
- [x] Mode downgrade logic verified (enforce/audit/shadow × medium severity)
- [x] Triage cannot override require_approval in enforce mode
- [x] Benchmark harness counts require_approval as successful prevention in TMPR


🤖 Generated with [Claude Code](https://claude.com/claude-code)