### PR TITLE
feat: add verdict caching for repeated tool calls

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,0 +1,175 @@
+package cache
+
+import (
+	"container/list"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/agentshield-ai/agentshield/internal/engine"
+	"github.com/agentshield-ai/agentshield/internal/models"
+	"github.com/agentshield-ai/agentshield/internal/triage"
+)
+
+// CachedVerdict stores the result of a previous evaluation for replay on cache hit.
+type CachedVerdict struct {
+	Action        models.Action        `json:"action"`
+	Alerts        []engine.RuleResult  `json:"alerts"`
+	TriageResults []triage.TriageResult `json:"triage_results,omitempty"`
+	CachedAt      time.Time            `json:"cached_at"`
+}
+
+// CacheStats exposes operational metrics for the verdict cache.
+type CacheStats struct {
+	Hits       uint64 `json:"hits"`
+	Misses     uint64 `json:"misses"`
+	Size       int    `json:"size"`
+	MaxSize    int    `json:"max_size"`
+	Evictions  uint64 `json:"evictions"`
+}
+
+// entry is the value stored in the doubly-linked list.
+type entry struct {
+	key     string
+	verdict *CachedVerdict
+}
+
+// VerdictCache is a thread-safe LRU cache with TTL-based expiry.
+// It uses a doubly-linked list + map for O(1) get/set/eviction.
+type VerdictCache struct {
+	mu       sync.RWMutex
+	maxSize  int
+	ttl      time.Duration
+	items    map[string]*list.Element
+	order    *list.List // front = most recently used
+	hits     uint64
+	misses   uint64
+	evictions uint64
+}
+
+// NewVerdictCache creates a new verdict cache with the given capacity and TTL.
+func NewVerdictCache(maxSize int, ttl time.Duration) *VerdictCache {
+	if maxSize <= 0 {
+		maxSize = 10000
+	}
+	if ttl <= 0 {
+		ttl = 5 * time.Minute
+	}
+	return &VerdictCache{
+		maxSize: maxSize,
+		ttl:     ttl,
+		items:   make(map[string]*list.Element, maxSize),
+		order:   list.New(),
+	}
+}
+
+// Get retrieves a cached verdict by key. Returns nil, false on miss or expiry.
+func (c *VerdictCache) Get(key string) (*CachedVerdict, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	elem, ok := c.items[key]
+	if !ok {
+		c.misses++
+		return nil, false
+	}
+
+	ent := elem.Value.(*entry)
+
+	// Check TTL expiry
+	if time.Since(ent.verdict.CachedAt) > c.ttl {
+		// Expired — evict
+		c.removeLocked(elem)
+		c.misses++
+		return nil, false
+	}
+
+	// Move to front (most recently used)
+	c.order.MoveToFront(elem)
+	c.hits++
+	return ent.verdict, true
+}
+
+// Set stores a verdict in the cache. If the cache is at capacity, the least
+// recently used entry is evicted first.
+func (c *VerdictCache) Set(key string, verdict *CachedVerdict) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// If key already exists, update in-place and promote
+	if elem, ok := c.items[key]; ok {
+		c.order.MoveToFront(elem)
+		elem.Value.(*entry).verdict = verdict
+		return
+	}
+
+	// Evict LRU if at capacity
+	for c.order.Len() >= c.maxSize {
+		c.evictLRULocked()
+	}
+
+	ent := &entry{key: key, verdict: verdict}
+	elem := c.order.PushFront(ent)
+	c.items[key] = elem
+}
+
+// Stats returns a snapshot of cache operational metrics.
+func (c *VerdictCache) Stats() CacheStats {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return CacheStats{
+		Hits:      c.hits,
+		Misses:    c.misses,
+		Size:      c.order.Len(),
+		MaxSize:   c.maxSize,
+		Evictions: c.evictions,
+	}
+}
+
+// Invalidate clears all entries from the cache. This should be called on rule
+// hot-reload to prevent stale verdicts from being served.
+func (c *VerdictCache) Invalidate() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.items = make(map[string]*list.Element, c.maxSize)
+	c.order.Init()
+}
+
+// CacheKey computes a deterministic SHA-256 cache key from a tool name and its
+// arguments. Arguments are sorted by key so that logically identical requests
+// (with args in different map-iteration order) produce the same key.
+func CacheKey(toolName string, args map[string]string) string {
+	keys := make([]string, 0, len(args))
+	for k := range args {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	h := sha256.New()
+	fmt.Fprintf(h, "tool=%s", toolName)
+	for _, k := range keys {
+		fmt.Fprintf(h, "\n%s=%s", k, args[k])
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// removeLocked removes an element from both the list and the map.
+// Caller must hold c.mu.
+func (c *VerdictCache) removeLocked(elem *list.Element) {
+	ent := c.order.Remove(elem).(*entry)
+	delete(c.items, ent.key)
+}
+
+// evictLRULocked removes the least recently used entry.
+// Caller must hold c.mu.
+func (c *VerdictCache) evictLRULocked() {
+	back := c.order.Back()
+	if back == nil {
+		return
+	}
+	c.removeLocked(back)
+	c.evictions++
+}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -19,6 +19,7 @@ type CachedVerdict struct {
 	Action        models.Action        `json:"action"`
 	Alerts        []engine.RuleResult  `json:"alerts"`
 	TriageResults []triage.TriageResult `json:"triage_results,omitempty"`
+	Overridable   bool                 `json:"overridable"`
 	CachedAt      time.Time            `json:"cached_at"`
 }
 

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,279 @@
+package cache
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/agentshield-ai/agentshield/internal/engine"
+	"github.com/agentshield-ai/agentshield/internal/models"
+)
+
+func makeVerdict(action models.Action) *CachedVerdict {
+	return &CachedVerdict{
+		Action:   action,
+		Alerts:   []engine.RuleResult{{RuleID: "r1", Matched: true}},
+		CachedAt: time.Now(),
+	}
+}
+
+func TestGet_miss_returns_false(t *testing.T) {
+	c := NewVerdictCache(10, time.Minute)
+	v, ok := c.Get("nonexistent")
+	if ok || v != nil {
+		t.Fatal("expected miss for nonexistent key")
+	}
+}
+
+func TestSet_and_Get_roundtrip(t *testing.T) {
+	c := NewVerdictCache(10, time.Minute)
+	verdict := makeVerdict(models.ActionBlock)
+	c.Set("k1", verdict)
+
+	got, ok := c.Get("k1")
+	if !ok {
+		t.Fatal("expected hit")
+	}
+	if got.Action != models.ActionBlock {
+		t.Fatalf("got action %s, want block", got.Action)
+	}
+	if len(got.Alerts) != 1 {
+		t.Fatalf("got %d alerts, want 1", len(got.Alerts))
+	}
+}
+
+func TestSet_update_existing_key(t *testing.T) {
+	c := NewVerdictCache(10, time.Minute)
+	c.Set("k1", makeVerdict(models.ActionBlock))
+	c.Set("k1", makeVerdict(models.ActionAllow))
+
+	got, ok := c.Get("k1")
+	if !ok {
+		t.Fatal("expected hit after update")
+	}
+	if got.Action != models.ActionAllow {
+		t.Fatalf("got action %s, want allow after update", got.Action)
+	}
+
+	stats := c.Stats()
+	if stats.Size != 1 {
+		t.Fatalf("expected size 1 after updating same key, got %d", stats.Size)
+	}
+}
+
+func TestEviction_at_capacity(t *testing.T) {
+	c := NewVerdictCache(3, time.Minute)
+
+	c.Set("a", makeVerdict(models.ActionAllow))
+	c.Set("b", makeVerdict(models.ActionAllow))
+	c.Set("c", makeVerdict(models.ActionAllow))
+
+	// This should evict "a" (LRU)
+	c.Set("d", makeVerdict(models.ActionBlock))
+
+	if _, ok := c.Get("a"); ok {
+		t.Fatal("expected 'a' to be evicted")
+	}
+	if _, ok := c.Get("d"); !ok {
+		t.Fatal("expected 'd' to be present")
+	}
+
+	stats := c.Stats()
+	if stats.Evictions != 1 {
+		t.Fatalf("expected 1 eviction, got %d", stats.Evictions)
+	}
+	if stats.Size != 3 {
+		t.Fatalf("expected size 3, got %d", stats.Size)
+	}
+}
+
+func TestEviction_promotes_accessed_entry(t *testing.T) {
+	c := NewVerdictCache(3, time.Minute)
+
+	c.Set("a", makeVerdict(models.ActionAllow))
+	c.Set("b", makeVerdict(models.ActionAllow))
+	c.Set("c", makeVerdict(models.ActionAllow))
+
+	// Access "a" to promote it
+	c.Get("a")
+
+	// Insert "d" — should evict "b" (now LRU), not "a"
+	c.Set("d", makeVerdict(models.ActionBlock))
+
+	if _, ok := c.Get("a"); !ok {
+		t.Fatal("expected 'a' to survive after promotion")
+	}
+	if _, ok := c.Get("b"); ok {
+		t.Fatal("expected 'b' to be evicted as LRU")
+	}
+}
+
+func TestTTL_expiry(t *testing.T) {
+	c := NewVerdictCache(10, 50*time.Millisecond)
+
+	verdict := &CachedVerdict{
+		Action:   models.ActionBlock,
+		CachedAt: time.Now(),
+	}
+	c.Set("k1", verdict)
+
+	// Immediate get should hit
+	if _, ok := c.Get("k1"); !ok {
+		t.Fatal("expected hit before TTL expiry")
+	}
+
+	// Wait for TTL to expire
+	time.Sleep(60 * time.Millisecond)
+
+	if _, ok := c.Get("k1"); ok {
+		t.Fatal("expected miss after TTL expiry")
+	}
+
+	stats := c.Stats()
+	if stats.Size != 0 {
+		t.Fatalf("expected expired entry to be removed, size=%d", stats.Size)
+	}
+}
+
+func TestCacheKey_deterministic_regardless_of_arg_order(t *testing.T) {
+	args1 := map[string]string{"path": "/etc/passwd", "command": "cat"}
+	args2 := map[string]string{"command": "cat", "path": "/etc/passwd"}
+
+	k1 := CacheKey("bash", args1)
+	k2 := CacheKey("bash", args2)
+
+	if k1 != k2 {
+		t.Fatalf("same args in different order produced different keys:\n  k1=%s\n  k2=%s", k1, k2)
+	}
+}
+
+func TestCacheKey_different_tools_different_keys(t *testing.T) {
+	args := map[string]string{"path": "/tmp"}
+	k1 := CacheKey("read_file", args)
+	k2 := CacheKey("write_file", args)
+
+	if k1 == k2 {
+		t.Fatal("different tool names should produce different keys")
+	}
+}
+
+func TestCacheKey_different_args_different_keys(t *testing.T) {
+	k1 := CacheKey("bash", map[string]string{"command": "ls"})
+	k2 := CacheKey("bash", map[string]string{"command": "rm -rf /"})
+
+	if k1 == k2 {
+		t.Fatal("different args should produce different keys")
+	}
+}
+
+func TestCacheKey_nil_args(t *testing.T) {
+	k1 := CacheKey("tool", nil)
+	k2 := CacheKey("tool", map[string]string{})
+
+	if k1 != k2 {
+		t.Fatalf("nil and empty args should produce the same key:\n  k1=%s\n  k2=%s", k1, k2)
+	}
+}
+
+func TestStats_accuracy(t *testing.T) {
+	c := NewVerdictCache(10, time.Minute)
+
+	// 2 misses
+	c.Get("x")
+	c.Get("y")
+
+	// 1 set + 1 hit
+	c.Set("x", makeVerdict(models.ActionAllow))
+	c.Get("x")
+
+	stats := c.Stats()
+	if stats.Hits != 1 {
+		t.Fatalf("expected 1 hit, got %d", stats.Hits)
+	}
+	if stats.Misses != 2 {
+		t.Fatalf("expected 2 misses, got %d", stats.Misses)
+	}
+	if stats.Size != 1 {
+		t.Fatalf("expected size 1, got %d", stats.Size)
+	}
+	if stats.MaxSize != 10 {
+		t.Fatalf("expected max_size 10, got %d", stats.MaxSize)
+	}
+}
+
+func TestInvalidate_clears_all_entries(t *testing.T) {
+	c := NewVerdictCache(10, time.Minute)
+	c.Set("a", makeVerdict(models.ActionAllow))
+	c.Set("b", makeVerdict(models.ActionBlock))
+
+	c.Invalidate()
+
+	if _, ok := c.Get("a"); ok {
+		t.Fatal("expected miss after invalidation")
+	}
+	if _, ok := c.Get("b"); ok {
+		t.Fatal("expected miss after invalidation")
+	}
+	stats := c.Stats()
+	if stats.Size != 0 {
+		t.Fatalf("expected size 0 after invalidation, got %d", stats.Size)
+	}
+}
+
+func TestInvalidate_preserves_counters(t *testing.T) {
+	c := NewVerdictCache(10, time.Minute)
+	c.Set("a", makeVerdict(models.ActionAllow))
+	c.Get("a") // hit
+
+	c.Invalidate()
+
+	stats := c.Stats()
+	if stats.Hits != 1 {
+		t.Fatalf("expected hits to be preserved after invalidation, got %d", stats.Hits)
+	}
+}
+
+func TestConcurrent_reads_and_writes(t *testing.T) {
+	c := NewVerdictCache(100, time.Minute)
+	const goroutines = 50
+	const opsPerGoroutine = 200
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for g := 0; g < goroutines; g++ {
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < opsPerGoroutine; i++ {
+				key := fmt.Sprintf("key-%d-%d", id, i%10)
+				if i%3 == 0 {
+					c.Set(key, makeVerdict(models.ActionAllow))
+				} else {
+					c.Get(key)
+				}
+			}
+		}(g)
+	}
+
+	wg.Wait()
+
+	// Verify internal consistency
+	stats := c.Stats()
+	if stats.Size < 0 || stats.Size > 100 {
+		t.Fatalf("cache size out of bounds: %d", stats.Size)
+	}
+	if stats.Hits+stats.Misses == 0 {
+		t.Fatal("expected some cache operations to be recorded")
+	}
+}
+
+func TestNewVerdictCache_defaults(t *testing.T) {
+	c := NewVerdictCache(0, 0)
+	if c.maxSize != 10000 {
+		t.Fatalf("expected default maxSize=10000, got %d", c.maxSize)
+	}
+	if c.ttl != 5*time.Minute {
+		t.Fatalf("expected default ttl=5m, got %s", c.ttl)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -111,11 +111,19 @@ type TestContextConfig struct {
 	Token   string `yaml:"token" json:"-"`
 }
 
+// CacheConfig controls the verdict caching layer.
+type CacheConfig struct {
+	Enabled bool `yaml:"enabled" json:"enabled"`    // default true
+	MaxSize int  `yaml:"max_size" json:"max_size"`  // default 10000
+	TTLSec  int  `yaml:"ttl_sec" json:"ttl_sec"`    // default 300 (5 minutes)
+}
+
 type Config struct {
 	Server         ServerConfig      `yaml:"server" json:"server"`
 	Auth           AuthConfig        `yaml:"auth" json:"auth"`
 	Rules          RulesConfig       `yaml:"rules" json:"rules"`
 	Store          StoreConfig       `yaml:"store" json:"store"`
+	Cache          CacheConfig       `yaml:"cache" json:"cache"`
 	Triage         TriageConfig      `yaml:"triage" json:"triage"`
 	DeepTriage     DeepTriageConfig  `yaml:"deep_triage" json:"deep_triage"`
 	TestContext    TestContextConfig `yaml:"test_context" json:"test_context"`
@@ -142,6 +150,11 @@ func LoadConfig(path string) (*Config, error) {
 			SQLitePath:           "./agentshield.db",
 			RetentionDays:        90,
 			CleanupIntervalHours: 24,
+		},
+		Cache: CacheConfig{
+			Enabled: true,
+			MaxSize: 10000,
+			TTLSec:  300,
 		},
 		Triage: TriageConfig{
 			Enabled:    false,

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/agentshield-ai/agentshield/internal/cache"
 	"github.com/agentshield-ai/agentshield/internal/config"
 	"github.com/agentshield-ai/agentshield/internal/engine"
 	"github.com/agentshield-ai/agentshield/internal/evaluate"
@@ -30,6 +31,7 @@ type Daemon struct {
 	triager         *triage.Triager
 	evaluator       *evaluate.Evaluator
 	server          *server.Server
+	verdictCache    *cache.VerdictCache
 	retentionCancel context.CancelFunc
 }
 
@@ -241,8 +243,18 @@ func (d *Daemon) initComponents() error {
 	d.evaluator = evaluate.NewEvaluator(d.engine, d.config.EvaluationMode, feedbackURL, triager, deepTriager)
 	d.logger.Info("Evaluator initialized", "mode", string(d.config.EvaluationMode))
 
+	// Initialize verdict cache
+	if d.config.Cache.Enabled {
+		ttl := time.Duration(d.config.Cache.TTLSec) * time.Second
+		d.verdictCache = cache.NewVerdictCache(d.config.Cache.MaxSize, ttl)
+		d.evaluator.SetCache(d.verdictCache)
+		d.logger.Info("Verdict cache initialized", "max_size", d.config.Cache.MaxSize, "ttl_sec", d.config.Cache.TTLSec)
+	} else {
+		d.logger.Info("Verdict cache disabled")
+	}
+
 	// Initialize server
-	srv, err := server.NewServer(d.config, d.evaluator, d.store, triager)
+	srv, err := server.NewServer(d.config, d.evaluator, d.store, triager, d.verdictCache)
 	if err != nil {
 		return fmt.Errorf("initializing server: %w", err)
 	}
@@ -252,13 +264,23 @@ func (d *Daemon) initComponents() error {
 	return nil
 }
 
-// reloadRules reloads the rule engine
+// reloadRules reloads the rule engine and invalidates the verdict cache.
 func (d *Daemon) reloadRules() error {
 	if d.engine == nil {
 		return fmt.Errorf("engine not initialized")
 	}
 
-	return d.engine.LoadRules()
+	if err := d.engine.LoadRules(); err != nil {
+		return err
+	}
+
+	// Invalidate cached verdicts so stale results are not served
+	if d.verdictCache != nil {
+		d.verdictCache.Invalidate()
+		d.logger.Info("Verdict cache invalidated after rule reload")
+	}
+
+	return nil
 }
 
 func (d *Daemon) startRetentionLoop() {

--- a/internal/evaluate/evaluate.go
+++ b/internal/evaluate/evaluate.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/agentshield-ai/agentshield/internal/cache"
 	"github.com/agentshield-ai/agentshield/internal/config"
 	"github.com/agentshield-ai/agentshield/internal/engine"
 	"github.com/agentshield-ai/agentshield/internal/models"
@@ -33,6 +34,7 @@ type EvaluationResponse struct {
 	Overridable   bool                  `json:"overridable"`
 	EffectiveMode config.EvaluationMode `json:"effective_mode"`
 	FeedbackURL   string                `json:"feedback_url,omitempty"`
+	Cached        bool                  `json:"cached"`
 	Timestamp     time.Time             `json:"timestamp"`
 }
 
@@ -49,6 +51,7 @@ type Evaluator struct {
 	feedbackURLBase string
 	triager         TriageService
 	deepTriager     DeepTriageService
+	cache           *cache.VerdictCache
 }
 
 // NewEvaluator creates a new evaluator
@@ -62,10 +65,34 @@ func NewEvaluator(eng RuleEvaluator, defaultMode config.EvaluationMode, feedback
 	}
 }
 
+// SetCache attaches a verdict cache to the evaluator. If nil, caching is disabled.
+func (e *Evaluator) SetCache(c *cache.VerdictCache) {
+	e.cache = c
+}
+
 // Evaluate processes an evaluation request and returns the appropriate response
 func (e *Evaluator) Evaluate(req *models.EvaluationRequest) (*EvaluationResponse, error) {
 	// Determine effective evaluation mode (server-side only)
 	effectiveMode := e.determineEffectiveMode()
+
+	// Check verdict cache before running rule evaluation
+	var cacheKey string
+	if e.cache != nil {
+		cacheKey = cache.CacheKey(req.Tool, req.Args)
+		if cached, ok := e.cache.Get(cacheKey); ok {
+			slog.Debug("Cache hit", "tool", req.Tool, "key", cacheKey)
+			return &EvaluationResponse{
+				EventID:       req.EventID,
+				Action:        cached.Action,
+				Alerts:        cached.Alerts,
+				TriageResults: cached.TriageResults,
+				Overridable:   false,
+				EffectiveMode: effectiveMode,
+				Cached:        true,
+				Timestamp:     time.Now(),
+			}, nil
+		}
+	}
 
 	// Run rule evaluation (engine now only returns matched rules)
 	alerts := e.engine.Evaluate(req.Fields)
@@ -119,6 +146,16 @@ func (e *Evaluator) Evaluate(req *models.EvaluationRequest) (*EvaluationResponse
 	// Add feedback URL if there are alerts
 	if len(alerts) > 0 && e.feedbackURLBase != "" {
 		response.FeedbackURL = fmt.Sprintf("%s?event_id=%s", e.feedbackURLBase, req.EventID)
+	}
+
+	// Store result in verdict cache
+	if e.cache != nil && cacheKey != "" {
+		e.cache.Set(cacheKey, &cache.CachedVerdict{
+			Action:        response.Action,
+			Alerts:        response.Alerts,
+			TriageResults: response.TriageResults,
+			CachedAt:      time.Now(),
+		})
 	}
 
 	// Fire deep triage async once at the end

--- a/internal/evaluate/evaluate.go
+++ b/internal/evaluate/evaluate.go
@@ -81,16 +81,20 @@ func (e *Evaluator) Evaluate(req *models.EvaluationRequest) (*EvaluationResponse
 		cacheKey = cache.CacheKey(req.Tool, req.Args)
 		if cached, ok := e.cache.Get(cacheKey); ok {
 			slog.Debug("Cache hit", "tool", req.Tool, "key", cacheKey)
-			return &EvaluationResponse{
+			resp := &EvaluationResponse{
 				EventID:       req.EventID,
 				Action:        cached.Action,
 				Alerts:        cached.Alerts,
 				TriageResults: cached.TriageResults,
-				Overridable:   false,
+				Overridable:   cached.Overridable,
 				EffectiveMode: effectiveMode,
 				Cached:        true,
 				Timestamp:     time.Now(),
-			}, nil
+			}
+			if len(cached.Alerts) > 0 && e.feedbackURLBase != "" {
+				resp.FeedbackURL = fmt.Sprintf("%s?event_id=%s", e.feedbackURLBase, req.EventID)
+			}
+			return resp, nil
 		}
 	}
 
@@ -154,6 +158,7 @@ func (e *Evaluator) Evaluate(req *models.EvaluationRequest) (*EvaluationResponse
 			Action:        response.Action,
 			Alerts:        response.Alerts,
 			TriageResults: response.TriageResults,
+			Overridable:   response.Overridable,
 			CachedAt:      time.Now(),
 		})
 	}

--- a/internal/server/security_test.go
+++ b/internal/server/security_test.go
@@ -28,7 +28,7 @@ func TestToolNameCommandValidation(t *testing.T) {
 	mockEngine := &mockRuleEngine{}
 	evaluator := evaluate.NewEvaluator(mockEngine, config.ModeAudit, "", nil, nil)
 
-	srv, err := NewServer(cfg, evaluator, testStore, nil)
+	srv, err := NewServer(cfg, evaluator, testStore, nil, nil)
 	if err != nil {
 		t.Fatalf("creating test server: %v", err)
 	}
@@ -82,7 +82,7 @@ func TestRawParamsValidationBypass(t *testing.T) {
 	mockEngine := &mockRuleEngine{}
 	evaluator := evaluate.NewEvaluator(mockEngine, config.ModeAudit, "", nil, nil)
 
-	srv, err := NewServer(cfg, evaluator, testStore, nil)
+	srv, err := NewServer(cfg, evaluator, testStore, nil, nil)
 	if err != nil {
 		t.Fatalf("creating test server: %v", err)
 	}
@@ -119,7 +119,7 @@ func TestHealthEndpointNoConfigLeak(t *testing.T) {
 	mockEngine := &mockRuleEngine{}
 	evaluator := evaluate.NewEvaluator(mockEngine, config.ModeEnforce, "", nil, nil)
 
-	srv, err := NewServer(cfg, evaluator, testStore, nil)
+	srv, err := NewServer(cfg, evaluator, testStore, nil, nil)
 	if err != nil {
 		t.Fatalf("creating test server: %v", err)
 	}
@@ -166,7 +166,7 @@ func TestSecurityHeadersPresent(t *testing.T) {
 	mockEngine := &mockRuleEngine{}
 	evaluator := evaluate.NewEvaluator(mockEngine, config.ModeAudit, "", nil, nil)
 
-	srv, err := NewServer(cfg, evaluator, testStore, nil)
+	srv, err := NewServer(cfg, evaluator, testStore, nil, nil)
 	if err != nil {
 		t.Fatalf("creating test server: %v", err)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -17,6 +17,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/agentshield-ai/agentshield/internal/auth"
+	"github.com/agentshield-ai/agentshield/internal/cache"
 	"github.com/agentshield-ai/agentshield/internal/config"
 	"github.com/agentshield-ai/agentshield/internal/evaluate"
 	"github.com/agentshield-ai/agentshield/internal/feedback"
@@ -54,6 +55,7 @@ type Server struct {
 	auth            *auth.Middleware
 	feedbackManager *feedback.FeedbackManager
 	triager         *triage.Triager
+	verdictCache    *cache.VerdictCache
 	httpServer      *http.Server
 	startTime       time.Time
 }
@@ -174,7 +176,7 @@ func validateEvaluationRequest(req *models.EvaluationRequest) error {
 }
 
 // NewServer creates a new HTTP server instance
-func NewServer(cfg *config.Config, evaluator *evaluate.Evaluator, store *store.Store, triager *triage.Triager) (*Server, error) {
+func NewServer(cfg *config.Config, evaluator *evaluate.Evaluator, store *store.Store, triager *triage.Triager, verdictCache *cache.VerdictCache) (*Server, error) {
 	// Create auth middleware if token is configured
 	var authMiddleware *auth.Middleware
 	if cfg.Auth.Token != "" {
@@ -195,6 +197,7 @@ func NewServer(cfg *config.Config, evaluator *evaluate.Evaluator, store *store.S
 		auth:            authMiddleware,
 		feedbackManager: feedbackManager,
 		triager:         triager,
+		verdictCache:    verdictCache,
 		startTime:       time.Now(),
 	}, nil
 }
@@ -564,11 +567,23 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 
 	// SECURITY: Minimal information disclosure in unauthenticated health endpoint.
 	// Detailed config is not exposed — use an authenticated status endpoint instead.
+	configInfo := map[string]interface{}{}
+	if s.verdictCache != nil {
+		stats := s.verdictCache.Stats()
+		configInfo["cache"] = map[string]interface{}{
+			"hits":      stats.Hits,
+			"misses":    stats.Misses,
+			"size":      stats.Size,
+			"max_size":  stats.MaxSize,
+			"evictions": stats.Evictions,
+		}
+	}
+
 	response := HealthResponse{
 		Status:        status,
 		Version:       "1.0.0",
 		UptimeSeconds: time.Since(s.startTime).Seconds(),
-		Config:        map[string]interface{}{},
+		Config:        configInfo,
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/server/server_edge_cases_test.go
+++ b/internal/server/server_edge_cases_test.go
@@ -483,7 +483,7 @@ func TestNewServerEdgeCases(t *testing.T) {
 		evaluator := evaluate.NewEvaluator(mockEngine, config.ModeEnforce, "", nil, nil)
 		testStore, _ := store.NewStore(":memory:")
 		
-		server, err := NewServer(cfg, evaluator, testStore, nil)
+		server, err := NewServer(cfg, evaluator, testStore, nil, nil)
 		if err != nil {
 			t.Fatalf("NewServer() error = %v", err)
 		}
@@ -504,7 +504,7 @@ func TestNewServerEdgeCases(t *testing.T) {
 		evaluator := evaluate.NewEvaluator(mockEngine, config.ModeEnforce, "", nil, nil)
 		testStore, _ := store.NewStore(":memory:")
 		
-		server, err := NewServer(cfg, evaluator, testStore, nil)
+		server, err := NewServer(cfg, evaluator, testStore, nil, nil)
 		if err != nil {
 			t.Fatalf("NewServer() unexpected error = %v", err)
 		}
@@ -527,7 +527,7 @@ func TestHandleAlertsEdgeCases(t *testing.T) {
 	testStore, _ := store.NewStore(":memory:")
 	defer testStore.Close()
 	
-	server, _ := NewServer(cfg, evaluator, testStore, nil)
+	server, _ := NewServer(cfg, evaluator, testStore, nil, nil)
 
 	// Insert test alerts
 	testAlerts := []*store.Alert{
@@ -737,7 +737,7 @@ func TestHandleEvaluateAdversarialInputs(t *testing.T) {
 	testStore, _ := store.NewStore(":memory:")
 	defer testStore.Close()
 	
-	server, _ := NewServer(cfg, evaluator, testStore, nil)
+	server, _ := NewServer(cfg, evaluator, testStore, nil, nil)
 
 	t.Run("request body too large", func(t *testing.T) {
 		// Create a JSON request body larger than MaxRequestBodySize (1MB)
@@ -852,7 +852,7 @@ func TestHandleEvaluateConcurrency(t *testing.T) {
 	testStore, _ := store.NewStore(":memory:")
 	defer testStore.Close()
 	
-	server, _ := NewServer(cfg, evaluator, testStore, nil)
+	server, _ := NewServer(cfg, evaluator, testStore, nil, nil)
 	
 	// Run concurrent requests
 	const numRequests = 50
@@ -912,7 +912,7 @@ func TestHandleFeedbackEdgeCases(t *testing.T) {
 		t.Fatalf("Failed to insert test alert: %v", err)
 	}
 	
-	server, _ := NewServer(cfg, evaluator, testStore, nil)
+	server, _ := NewServer(cfg, evaluator, testStore, nil, nil)
 
 	t.Run("invalid feedback type", func(t *testing.T) {
 		feedback := FeedbackRequest{

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -83,7 +83,7 @@ func TestHandleEvaluate(t *testing.T) {
 	// Create real evaluator with mock engine
 	evaluator := evaluate.NewEvaluator(mockEngine, config.ModeAudit, "", nil, nil)
 
-	server, err := NewServer(cfg, evaluator, testStore, nil)
+	server, err := NewServer(cfg, evaluator, testStore, nil, nil)
 	if err != nil {
 		t.Fatalf("creating test server: %v", err)
 	}
@@ -180,7 +180,7 @@ func TestHandleEvaluateBodyTooLarge(t *testing.T) {
 	testStore, _ := store.NewStore(":memory:")
 	defer testStore.Close()
 
-	server, err := NewServer(cfg, evaluator, testStore, nil)
+	server, err := NewServer(cfg, evaluator, testStore, nil, nil)
 	if err != nil {
 		t.Fatalf("creating test server: %v", err)
 	}
@@ -217,7 +217,7 @@ func TestHandleHealth(t *testing.T) {
 	mockEngine := &mockRuleEngine{}
 	evaluator := evaluate.NewEvaluator(mockEngine, config.ModeAudit, "", nil, nil)
 	
-	server, err := NewServer(cfg, evaluator, testStore, nil)
+	server, err := NewServer(cfg, evaluator, testStore, nil, nil)
 	if err != nil {
 		t.Fatalf("creating test server: %v", err)
 	}
@@ -311,7 +311,7 @@ func TestHandleAlerts(t *testing.T) {
 	mockEngine := &mockRuleEngine{}
 	evaluator := evaluate.NewEvaluator(mockEngine, config.ModeAudit, "", nil, nil)
 	
-	server, err := NewServer(cfg, evaluator, testStore, nil)
+	server, err := NewServer(cfg, evaluator, testStore, nil, nil)
 	if err != nil {
 		t.Fatalf("creating test server: %v", err)
 	}
@@ -427,7 +427,7 @@ func TestHandleFeedbackPost(t *testing.T) {
 	mockEngine := &mockRuleEngine{}
 	evaluator := evaluate.NewEvaluator(mockEngine, config.ModeAudit, "", nil, nil)
 	
-	server, err := NewServer(cfg, evaluator, testStore, nil)
+	server, err := NewServer(cfg, evaluator, testStore, nil, nil)
 	if err != nil {
 		t.Fatalf("creating test server: %v", err)
 	}
@@ -495,7 +495,7 @@ func TestHandleFeedbackGet(t *testing.T) {
 	mockEngine := &mockRuleEngine{}
 	evaluator := evaluate.NewEvaluator(mockEngine, config.ModeAudit, "", nil, nil)
 	
-	server, err := NewServer(cfg, evaluator, testStore, nil)
+	server, err := NewServer(cfg, evaluator, testStore, nil, nil)
 	if err != nil {
 		t.Fatalf("creating test server: %v", err)
 	}
@@ -575,7 +575,7 @@ func TestNewServer(t *testing.T) {
 	evaluator := evaluate.NewEvaluator(mockEngine, config.ModeAudit, "", nil, nil)
 	triager := &triage.Triager{}
 
-	server, err := NewServer(cfg, evaluator, testStore, triager)
+	server, err := NewServer(cfg, evaluator, testStore, triager, nil)
 	if err != nil {
 		t.Errorf("NewServer() failed: %v", err)
 	}
@@ -612,7 +612,7 @@ func TestNewServerWithoutAuth(t *testing.T) {
 	mockEngine := &mockRuleEngine{}
 	evaluator := evaluate.NewEvaluator(mockEngine, config.ModeAudit, "", nil, nil)
 
-	server, err := NewServer(cfg, evaluator, testStore, nil)
+	server, err := NewServer(cfg, evaluator, testStore, nil, nil)
 	if err != nil {
 		t.Errorf("NewServer() failed: %v", err)
 	}
@@ -633,7 +633,7 @@ func TestRequestLogger(t *testing.T) {
 	mockEngine := &mockRuleEngine{}
 	evaluator := evaluate.NewEvaluator(mockEngine, config.ModeAudit, "", nil, nil)
 	
-	server, err := NewServer(cfg, evaluator, testStore, nil)
+	server, err := NewServer(cfg, evaluator, testStore, nil, nil)
 	if err != nil {
 		t.Fatalf("creating test server: %v", err)
 	}
@@ -682,7 +682,7 @@ func TestHandleHealthDegraded(t *testing.T) {
 	mockEngine := &mockRuleEngine{}
 	evaluator := evaluate.NewEvaluator(mockEngine, config.ModeAudit, "", nil, nil)
 	
-	server, err := NewServer(cfg, evaluator, testStore, nil)
+	server, err := NewServer(cfg, evaluator, testStore, nil, nil)
 	if err != nil {
 		t.Fatalf("creating test server: %v", err)
 	}
@@ -758,7 +758,7 @@ func TestHandleAlertsWithFilters(t *testing.T) {
 	mockEngine := &mockRuleEngine{}
 	evaluator := evaluate.NewEvaluator(mockEngine, config.ModeAudit, "", nil, nil)
 	
-	server, err := NewServer(cfg, evaluator, testStore, nil)
+	server, err := NewServer(cfg, evaluator, testStore, nil, nil)
 	if err != nil {
 		t.Fatalf("creating test server: %v", err)
 	}
@@ -907,7 +907,7 @@ func TestHandleFeedbackSubmissionErrors(t *testing.T) {
 	mockEngine := &mockRuleEngine{}
 	evaluator := evaluate.NewEvaluator(mockEngine, config.ModeAudit, "", nil, nil)
 	
-	server, err := NewServer(cfg, evaluator, testStore, nil)
+	server, err := NewServer(cfg, evaluator, testStore, nil, nil)
 	if err != nil {
 		t.Fatalf("creating test server: %v", err)
 	}
@@ -967,7 +967,7 @@ func TestHandleFeedbackQueryWithLimits(t *testing.T) {
 	mockEngine := &mockRuleEngine{}
 	evaluator := evaluate.NewEvaluator(mockEngine, config.ModeAudit, "", nil, nil)
 	
-	server, err := NewServer(cfg, evaluator, testStore, nil)
+	server, err := NewServer(cfg, evaluator, testStore, nil, nil)
 	if err != nil {
 		t.Fatalf("creating test server: %v", err)
 	}
@@ -1059,7 +1059,7 @@ func TestHandleEvaluateFieldMapping(t *testing.T) {
 
 	evaluator := evaluate.NewEvaluator(mockEngine, config.ModeAudit, "", nil, nil)
 	
-	server, err := NewServer(cfg, evaluator, testStore, nil)
+	server, err := NewServer(cfg, evaluator, testStore, nil, nil)
 	if err != nil {
 		t.Fatalf("creating test server: %v", err)
 	}
@@ -1121,7 +1121,7 @@ func TestStartAndShutdown(t *testing.T) {
 	mockEngine := &mockRuleEngine{}
 	evaluator := evaluate.NewEvaluator(mockEngine, config.ModeAudit, "", nil, nil)
 	
-	server, err := NewServer(cfg, evaluator, testStore, nil)
+	server, err := NewServer(cfg, evaluator, testStore, nil, nil)
 	if err != nil {
 		t.Fatalf("creating test server: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Adds an in-memory LRU verdict cache with configurable TTL to avoid re-evaluating identical tool calls
- Cache key is SHA-256 of tool_name + sorted args (order-independent)
- Cache is invalidated on SIGHUP rule hot-reload to prevent stale verdicts
- Cache hit/miss stats exposed on health endpoint
- Triage is skipped entirely on cache hits

## Motivation

Agents frequently make repeated identical tool calls (e.g. `ls`, `git status`). Caching verdicts avoids redundant Sigma evaluation and triage for these, reducing latency to near-zero on repeat calls.

## Changes

| File | Change |
|---|---|
| `internal/cache/cache.go` | LRU cache with doubly-linked list + map (O(1) ops, no external deps) |
| `internal/cache/cache_test.go` | 15 tests (eviction, TTL, thread safety, key determinism) |
| `internal/config/config.go` | `CacheConfig` (enabled=true, max_size=10000, ttl_sec=300) |
| `internal/evaluate/evaluate.go` | Cache check before eval, cache store after, `cached` response field |
| `internal/server/server.go` | Cache stats in health endpoint |
| `internal/daemon/daemon.go` | Cache creation, wiring, SIGHUP invalidation |

## Configuration

```yaml
cache:
  enabled: true
  max_size: 10000
  ttl_sec: 300
```

## Test plan

- [x] 15/15 cache package tests pass (including 50-goroutine concurrency test)
- [x] 22/22 evaluate tests pass
- [x] All server tests pass
- [x] Cache invalidated on rule reload verified
- [x] Same args in different order produce same cache key


🤖 Generated with [Claude Code](https://claude.com/claude-code)