### PR TITLE
fix: address pre-release review findings (7 issues)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,7 @@ See [PLATFORMS.md](PLATFORMS.md) for full details. Detection rules target Linux/
 - **Branch naming**: `<type>/<short-description>` (e.g. `feat/new-rule`).
 - **Security**: Constant-time auth comparison (`subtle.ConstantTimeCompare`), UTF-8 validation, length limits, and control character rejection on all input.
 - **Tests**: Table-driven Go tests. Security-specific test files (`security_test.go`) in most packages. Integration tests that depend on project rules use `runtime.Caller` to find the project root and `t.Skip` if rules are absent.
-- **NewServer signature**: `NewServer(cfg, evaluator, store, triager, verdictCache)` — the 5th parameter is `*cache.VerdictCache` (can be nil).
+- **NewServer signature**: `NewServer(cfg, evaluator, store, verdictCache)` — the 4th parameter is `*cache.VerdictCache` (can be nil). The triager is injected into the evaluator, not passed to the server.
 
 ## CI
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,62 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, colour, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behaviour that contributes to a positive environment:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologising to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behaviour:
+
+* The use of sexualised language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behaviour and will take appropriate and fair corrective action in
+response to any behaviour that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be
+reported to the community leaders responsible for enforcement at
+**security@agentshield.ai**.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/),
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in AgentShield, please report it responsibly.
+
+**Email:** [security@agentshield.ai](mailto:security@agentshield.ai)
+
+Please include:
+
+- A description of the vulnerability
+- Steps to reproduce the issue
+- The potential impact
+- Any suggested fix (optional)
+
+## Response Timeline
+
+- **Acknowledgement:** within 48 hours
+- **Initial assessment:** within 5 business days
+- **Fix or mitigation:** depends on severity, but we aim for 30 days for critical issues
+
+## Scope
+
+This policy covers:
+
+- The AgentShield Go engine (`cmd/`, `internal/`, `pkg/`)
+- The OpenClaw plugin (`plugins/openclaw/`)
+- The Claude Code hook (`plugins/claude/`)
+- Sigma detection rules (`rules/`)
+- Installation and deployment scripts (`scripts/`, `plugins/openclaw/skill/`)
+
+## Disclosure
+
+We follow coordinated disclosure. We ask that you do not publicly disclose the vulnerability until we have released a fix or 90 days have passed since your report, whichever comes first.
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest release | Yes |
+| Older releases | Best effort |

--- a/cmd/agentshield/main.go
+++ b/cmd/agentshield/main.go
@@ -356,23 +356,9 @@ func loadConfig() (*config.Config, error) {
 	return cfg, nil
 }
 
-// setupLogging configures the log output
+// setupLogging configures early log output before the daemon takes over with slog.
 func setupLogging(level string) {
-	// Basic logging setup - in production you might want structured logging
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
-
-	// Set log level (basic implementation)
-	switch strings.ToLower(level) {
-	case "debug":
-		// Enable all logging
-	case "info":
-		// Default level
-	case "warn", "warning":
-		// Could filter out debug/info logs
-	case "error":
-		// Could filter out debug/info/warn logs
-	}
-
 	if verbose {
 		log.Printf("Log level set to: %s", level)
 	}

--- a/plugins/claude/agentshield-hook.sh
+++ b/plugins/claude/agentshield-hook.sh
@@ -3,19 +3,19 @@
 # Evaluates tool calls against AgentShield engine before execution.
 #
 # Install: Add to ~/.claude/settings.json under hooks.PreToolUse
-# Requires: AgentShield engine running (default: http://127.0.0.1:8432)
+# Requires: AgentShield engine running (default: http://127.0.0.1:8433)
 #
 # Exit codes:
 #   0 = allow (no output or {"decision":"approve"})
 #   2 = block ({"decision":"block","reason":"..."})
 #
 # Environment:
-#   AGENTSHIELD_URL         - Engine URL (default: http://127.0.0.1:8432)
+#   AGENTSHIELD_URL         - Engine URL (default: http://127.0.0.1:8433)
 #   AGENTSHIELD_AUTH_TOKEN  - Engine auth token (required when auth is enabled)
 
 set -euo pipefail
 
-AGENTSHIELD_URL="${AGENTSHIELD_URL:-http://127.0.0.1:8432}"
+AGENTSHIELD_URL="${AGENTSHIELD_URL:-http://127.0.0.1:8433}"
 AGENTSHIELD_AUTH_TOKEN="${AGENTSHIELD_AUTH_TOKEN:-}"
 
 # Read JSON input from stdin (Claude Code passes tool call context)

--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -15,12 +15,12 @@
       "intercept": {
         "type": "array",
         "items": { "type": "string" },
-        "default": ["exec", "write", "edit", "browser", "message", "sessions_spawn"]
+        "default": ["exec", "write", "edit", "read", "browser", "message", "sessions_spawn"]
       },
       "skip": {
         "type": "array",
         "items": { "type": "string" },
-        "default": ["read", "session_status"]
+        "default": ["session_status"]
       },
       "circuit_breaker": {
         "type": "object",


### PR DESCRIPTION
Critical:
- Fix Claude Code hook default port 8432 → 8433 (matches engine default)

High:
- Remove misleading setupLogging stub; daemon handles slog setup
- Align openclaw.plugin.json defaults with config.ts (intercept/skip lists)

Medium:
- Fix CLAUDE.md NewServer signature (4 params, not 5; triager is on evaluator)
- Add SECURITY.md with vulnerability disclosure policy
- Add CODE_OF_CONDUCT.md (Contributor Covenant 2.1)

https://claude.ai/code/session_01SsYrTB3B5Fcf9r4MxhWCP8