### PR TITLE
fix: repair two flaky tests for CI-clean test suite

### DIFF
--- a/internal/config/security_test.go
+++ b/internal/config/security_test.go
@@ -9,39 +9,40 @@ import (
 // TestSSRFBypassVectors verifies H-1: SSRF protection catches bypass vectors
 // like hex-encoded IPs, IPv6 loopback, and URL userinfo.
 func TestSSRFBypassVectors(t *testing.T) {
+	_, dnsErr := net.LookupIP("api.openai.com")
+	hasDNS := dnsErr == nil
+
 	tests := []struct {
-		name     string
-		url      string
-		expected bool // true = private/local
+		name        string
+		url         string
+		expected    bool // true = private/local
+		requiresDNS bool
 	}{
-		{"plain localhost", "https://localhost/api", true},
-		{"127.0.0.1", "https://127.0.0.1/api", true},
-		{"IPv6 loopback", "https://[::1]/api", true},
-		{"10.x private", "https://10.0.0.1/api", true},
-		{"192.168.x private", "https://192.168.1.1/api", true},
-		{"172.16.x private", "https://172.16.0.1/api", true},
-		{"unspecified 0.0.0.0", "https://0.0.0.0/api", true},
-		{"ip6-localhost", "https://ip6-localhost/api", true},
-		{"malformed URL fails closed", "ht!tp://broken", true},
-		{"empty hostname fails closed", "https:///path", true},
-		{"public IP allowed", "https://8.8.8.8/api", false},
-		{"public domain allowed", "https://api.openai.com/v1", false},
+		{"plain localhost", "https://localhost/api", true, false},
+		{"127.0.0.1", "https://127.0.0.1/api", true, false},
+		{"IPv6 loopback", "https://[::1]/api", true, false},
+		{"10.x private", "https://10.0.0.1/api", true, false},
+		{"192.168.x private", "https://192.168.1.1/api", true, false},
+		{"172.16.x private", "https://172.16.0.1/api", true, false},
+		{"unspecified 0.0.0.0", "https://0.0.0.0/api", true, false},
+		{"ip6-localhost", "https://ip6-localhost/api", true, false},
+		{"malformed URL fails closed", "ht!tp://broken", true, false},
+		{"empty hostname fails closed", "https:///path", true, false},
+		{"public IP allowed", "https://8.8.8.8/api", false, false},
+		{"public domain allowed", "https://api.openai.com/v1", false, true},
 		// IPv4-mapped IPv6 bypass vectors (new hardening)
-		{"IPv4-mapped loopback", "https://[::ffff:127.0.0.1]/api", true},
-		{"IPv4-mapped private 10.x", "https://[::ffff:10.0.0.1]/api", true},
-		{"IPv4-mapped private 192.168.x", "https://[::ffff:192.168.1.1]/api", true},
-		{"IPv4-mapped public allowed", "https://[::ffff:8.8.8.8]/api", false},
+		{"IPv4-mapped loopback", "https://[::ffff:127.0.0.1]/api", true, false},
+		{"IPv4-mapped private 10.x", "https://[::ffff:10.0.0.1]/api", true, false},
+		{"IPv4-mapped private 192.168.x", "https://[::ffff:192.168.1.1]/api", true, false},
+		{"IPv4-mapped public allowed", "https://[::ffff:8.8.8.8]/api", false, false},
 		// URL userinfo SSRF bypass vector
-		{"userinfo bypass attempt", "https://admin@127.0.0.1/api", true},
+		{"userinfo bypass attempt", "https://admin@127.0.0.1/api", true, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Skip DNS-dependent test cases when DNS is unavailable
-			if tt.name == "public domain allowed" {
-				if _, err := net.LookupIP("api.openai.com"); err != nil {
-					t.Skip("skipping: DNS resolution unavailable")
-				}
+			if tt.requiresDNS && !hasDNS {
+				t.Skip("DNS resolution unavailable")
 			}
 			result := IsPrivateOrLocalURL(tt.url)
 			if result != tt.expected {

--- a/internal/config/security_test.go
+++ b/internal/config/security_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"net"
 	"net/netip"
 	"testing"
 )
@@ -36,6 +37,12 @@ func TestSSRFBypassVectors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Skip DNS-dependent test cases when DNS is unavailable
+			if tt.name == "public domain allowed" {
+				if _, err := net.LookupIP("api.openai.com"); err != nil {
+					t.Skip("skipping: DNS resolution unavailable")
+				}
+			}
 			result := IsPrivateOrLocalURL(tt.url)
 			if result != tt.expected {
 				t.Errorf("IsPrivateOrLocalURL(%q) = %v, want %v", tt.url, result, tt.expected)

--- a/internal/session/registry.go
+++ b/internal/session/registry.go
@@ -368,11 +368,11 @@ func (r *Registry) crossSessionFieldsLocked(excludeSessionID string, correlation
 // appear in other sessions' recent events. Must be called with r.mu held.
 func (r *Registry) computeToolOverlap(excludeSessionID string, correlationWindow time.Duration) string {
 	if excludeSessionID == "" {
-		return "0.0"
+		return "0.00"
 	}
 	state, ok := r.sessions[excludeSessionID]
 	if !ok || len(state.events) == 0 {
-		return "0.0"
+		return "0.00"
 	}
 
 	myTools := make(map[string]struct{})
@@ -380,7 +380,7 @@ func (r *Registry) computeToolOverlap(excludeSessionID string, correlationWindow
 		myTools[ev.Tool] = struct{}{}
 	}
 	if len(myTools) == 0 {
-		return "0.0"
+		return "0.00"
 	}
 
 	cutoff := time.Now().Add(-correlationWindow)

--- a/internal/session/registry_test.go
+++ b/internal/session/registry_test.go
@@ -179,8 +179,8 @@ func TestRegistry_CrossSessionFields_Empty(t *testing.T) {
 	if fields["session.cross_session_count"] != "0" {
 		t.Errorf("expected 0 other sessions, got %q", fields["session.cross_session_count"])
 	}
-	if fields["session.cross_session_tool_overlap"] != "0.0" {
-		t.Errorf("expected 0.0 overlap, got %q", fields["session.cross_session_tool_overlap"])
+	if fields["session.cross_session_tool_overlap"] != "0.00" {
+		t.Errorf("expected 0.00 overlap, got %q", fields["session.cross_session_tool_overlap"])
 	}
 }
 


### PR DESCRIPTION
- Skip DNS-dependent SSRF test case when DNS resolution is unavailable
  (e.g., sandboxed CI environments)
- Fix cross-session overlap assertion to match %.2f format ("0.00" not "0.0")

https://claude.ai/code/session_01VbsC4ny1VLgGhFEJ9Fgtdw