### PR TITLE
feat: add Hermes agentic framework connector plugin

### DIFF
--- a/plugins/hermes/__init__.py
+++ b/plugins/hermes/__init__.py
@@ -6,9 +6,9 @@ standard Hermes plugin via ``~/.hermes/plugins/agentshield/``.
 
 Hooks registered
 ~~~~~~~~~~~~~~~~
-- ``pre_tool_call``  — synchronous security evaluation before each tool runs
-- ``post_tool_call`` — fire-and-forget audit report after each tool completes
-- ``on_session_start`` / ``on_session_end`` — lifecycle tracking
+- ``pre_tool_call``  -- synchronous security evaluation before each tool runs
+- ``post_tool_call`` -- fire-and-forget audit report after each tool completes
+- ``on_session_start`` / ``on_session_end`` -- lifecycle tracking
 """
 
 from __future__ import annotations
@@ -28,14 +28,12 @@ from .event_builder import (
     build_evaluation_request,
     build_lifecycle_event,
 )
-from .normalise import normalise_tool_name
+from .normalise import normalise_tool_call
 
 logger = logging.getLogger("agentshield")
 
-# Max age (seconds) for entries in the pending evaluations correlation map.
 _CORRELATION_TTL_S = 60.0
 
-# Severity ordering for notification filtering.
 _SEVERITY_ORDER: Dict[str, int] = {"low": 0, "medium": 1, "high": 2, "critical": 3}
 _NOTIFY_THRESHOLD: Dict[str, int] = {"all": 0, "high": 2, "critical": 3, "none": 999}
 
@@ -60,14 +58,13 @@ def _format_alert_message(
     action: str,
     notify_level: str,
 ) -> Optional[str]:
-    """Build a human-readable alert string for the user, or ``None``."""
+    """Build a human-readable alert string, or ``None`` if below threshold."""
     alerts = response.get("alerts") or []
     if not alerts:
         return None
 
     threshold = _NOTIFY_THRESHOLD.get(notify_level, 2)
-    meets = any(_SEVERITY_ORDER.get(a.get("severity", ""), 0) >= threshold for a in alerts)
-    if not meets:
+    if not any(_SEVERITY_ORDER.get(a.get("severity", ""), 0) >= threshold for a in alerts):
         return None
 
     top = alerts[0]
@@ -108,27 +105,33 @@ class _CorrelationTracker:
         self._lock = threading.Lock()
         self._pending: Dict[str, Deque[Tuple[str, float]]] = {}
 
+    @staticmethod
+    def _key(task_id: Optional[str], tool_name: str) -> str:
+        return f"{task_id or ''}:{tool_name}"
+
     def push(self, task_id: Optional[str], tool_name: str, event_id: str) -> None:
-        key = f"{task_id or ''}:{tool_name}"
+        key = self._key(task_id, tool_name)
         with self._lock:
-            bucket = self._pending.setdefault(key, deque())
-            bucket.append((event_id, time.monotonic()))
+            self._pending.setdefault(key, deque()).append(
+                (event_id, time.monotonic())
+            )
 
     def pop(self, task_id: Optional[str], tool_name: str) -> Optional[str]:
-        key = f"{task_id or ''}:{tool_name}"
+        key = self._key(task_id, tool_name)
         now = time.monotonic()
         with self._lock:
-            # Purge stale entries across all buckets opportunistically.
-            for k in list(self._pending):
-                q = self._pending[k]
-                while q and (now - q[0][1]) > _CORRELATION_TTL_S:
-                    q.popleft()
-                if not q:
-                    del self._pending[k]
-
             bucket = self._pending.get(key)
             if not bucket:
                 return None
+
+            # Purge stale entries in this bucket only.
+            while bucket and (now - bucket[0][1]) > _CORRELATION_TTL_S:
+                bucket.popleft()
+
+            if not bucket:
+                del self._pending[key]
+                return None
+
             event_id, _ = bucket.popleft()
             if not bucket:
                 del self._pending[key]
@@ -140,9 +143,8 @@ class _CorrelationTracker:
 # ---------------------------------------------------------------------------
 
 def register(ctx: Any) -> None:
-    """Hermes plugin entry-point — called once at startup."""
+    """Hermes plugin entry-point -- called once at startup."""
 
-    # Build config from Hermes settings + env vars.
     raw_settings: Dict[str, Any] = {}
     for field_name in (
         "enabled", "endpoint", "auth_token", "timeout_ms", "timeout_policy",
@@ -184,17 +186,15 @@ def register(ctx: Any) -> None:
         Returns ``{"block": True, "reason": "..."}`` to prevent execution,
         or ``None`` to allow.
         """
-        canonical = normalise_tool_name(tool_name)
+        safe_args = args if isinstance(args, dict) else {}
+        canonical, command = normalise_tool_call(tool_name, safe_args)
 
-        # Skip list takes precedence.
         if tool_name in skip_set or canonical in skip_set:
             return None
 
-        # If an intercept list is configured, only evaluate listed tools.
         if intercept_set and tool_name not in intercept_set and canonical not in intercept_set:
             return None
 
-        # Circuit breaker check.
         if breaker.is_open():
             logger.warning(
                 "AgentShield circuit breaker open, applying %s policy",
@@ -204,8 +204,10 @@ def register(ctx: Any) -> None:
 
         request = build_evaluation_request(
             tool_name,
-            args if isinstance(args, dict) else {},
+            safe_args,
             task_id=task_id,
+            canonical_name=canonical,
+            command=command,
         )
 
         try:
@@ -220,7 +222,6 @@ def register(ctx: Any) -> None:
                     effective_mode,
                 )
 
-            # Log triage results.
             for triage in response.get("triage_results") or []:
                 logger.info(
                     "AgentShield triage: %s (%s) - %s",
@@ -260,7 +261,6 @@ def register(ctx: Any) -> None:
 
                 return {"block": True, "reason": reason}
 
-            # High-confidence triage allow overrides rule alerts.
             has_hc_allow = any(
                 t.get("verdict") == "allow" and (t.get("confidence") or 0) > 0.8
                 for t in (response.get("triage_results") or [])
@@ -282,9 +282,8 @@ def register(ctx: Any) -> None:
                 if msg:
                     logger.warning(msg)
 
-            # Queue for post_tool_call correlation.
             correlation.push(task_id, tool_name, request["event_id"])
-            return None  # allow
+            return None
 
         except Exception as exc:
             breaker.record_failure()
@@ -301,31 +300,30 @@ def register(ctx: Any) -> None:
         **kwargs: Any,
     ) -> None:
         """Send a fire-and-forget audit report after tool execution."""
+        safe_args = args if isinstance(args, dict) else {}
         corr_id = correlation.pop(task_id, tool_name) or str(uuid.uuid4())
-
-        is_error = isinstance(result, str) and result.startswith("Error")
-        error_message = result if is_error else None
+        canonical, _ = normalise_tool_call(tool_name, safe_args)
 
         report = build_audit_report(
             tool_name,
-            args if isinstance(args, dict) else {},
+            safe_args,
             result,
             correlation_id=corr_id,
             task_id=task_id,
-            is_error=is_error,
-            error_message=error_message,
+            canonical_name=canonical,
         )
         client.send_audit(report)
 
     # ---- lifecycle hooks ------------------------------------------------
 
+    def _on_lifecycle(event_type: str, task_id: Optional[str] = None, **kwargs: Any) -> None:
+        client.send_lifecycle(build_lifecycle_event(event_type, task_id=task_id))
+
     def _on_session_start(task_id: Optional[str] = None, **kwargs: Any) -> None:
-        event = build_lifecycle_event("session_start", task_id=task_id)
-        client.send_lifecycle(event)
+        _on_lifecycle("session_start", task_id)
 
     def _on_session_end(task_id: Optional[str] = None, **kwargs: Any) -> None:
-        event = build_lifecycle_event("session_end", task_id=task_id)
-        client.send_lifecycle(event)
+        _on_lifecycle("session_end", task_id)
 
     # ---- register hooks -------------------------------------------------
 

--- a/plugins/hermes/__init__.py
+++ b/plugins/hermes/__init__.py
@@ -1,0 +1,351 @@
+"""AgentShield plugin for Hermes Agent.
+
+Evaluates every tool call against the AgentShield detection engine and
+returns block / require_approval / allow / log decisions.  Installs as a
+standard Hermes plugin via ``~/.hermes/plugins/agentshield/``.
+
+Hooks registered
+~~~~~~~~~~~~~~~~
+- ``pre_tool_call``  — synchronous security evaluation before each tool runs
+- ``post_tool_call`` — fire-and-forget audit report after each tool completes
+- ``on_session_start`` / ``on_session_end`` — lifecycle tracking
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+import uuid
+from collections import deque
+from typing import Any, Deque, Dict, Optional, Tuple
+
+from .circuit_breaker import CircuitBreaker
+from .client import AgentShieldClient
+from .config import parse_config
+from .event_builder import (
+    build_audit_report,
+    build_evaluation_request,
+    build_lifecycle_event,
+)
+from .normalise import normalise_tool_name
+
+logger = logging.getLogger("agentshield")
+
+# Max age (seconds) for entries in the pending evaluations correlation map.
+_CORRELATION_TTL_S = 60.0
+
+# Severity ordering for notification filtering.
+_SEVERITY_ORDER: Dict[str, int] = {"low": 0, "medium": 1, "high": 2, "critical": 3}
+_NOTIFY_THRESHOLD: Dict[str, int] = {"all": 0, "high": 2, "critical": 3, "none": 999}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _apply_timeout_policy(policy: str) -> Optional[Dict[str, Any]]:
+    """Return a blocking dict when the policy says *block*, else ``None``."""
+    if policy == "block":
+        return {
+            "block": True,
+            "reason": "AgentShield unavailable (fail-closed policy)",
+        }
+    return None
+
+
+def _format_alert_message(
+    response: Dict[str, Any],
+    tool_name: str,
+    action: str,
+    notify_level: str,
+) -> Optional[str]:
+    """Build a human-readable alert string for the user, or ``None``."""
+    alerts = response.get("alerts") or []
+    if not alerts:
+        return None
+
+    threshold = _NOTIFY_THRESHOLD.get(notify_level, 2)
+    meets = any(_SEVERITY_ORDER.get(a.get("severity", ""), 0) >= threshold for a in alerts)
+    if not meets:
+        return None
+
+    top = alerts[0]
+    severity = top.get("severity", "unknown")
+    emoji_map = {"critical": "\U0001f534", "high": "\U0001f7e0", "medium": "\U0001f7e1", "low": "\U0001f535"}
+    emoji = emoji_map.get(severity, "\u26aa")
+
+    parts = [
+        f"\U0001f6e1\ufe0f AgentShield Alert \u2014 {action} ({severity})",
+        f"{emoji} {top.get('rule_name', 'unknown rule')}",
+        f"Tool: {tool_name}",
+    ]
+
+    command = (top.get("matched_fields") or {}).get("command")
+    if isinstance(command, str):
+        truncated = command[:200] + "..." if len(command) > 200 else command
+        parts.append(f"Command: {truncated}")
+
+    triage = (response.get("triage_results") or [None])[0]
+    if triage:
+        parts.append(f"Triage: {triage.get('verdict')} (confidence: {triage.get('confidence')})")
+        parts.append(f"Reasoning: {triage.get('reasoning', '')}")
+
+    if len(alerts) > 1:
+        parts.append(f"(+{len(alerts) - 1} more alert{'s' if len(alerts) > 2 else ''})")
+
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Correlation tracker
+# ---------------------------------------------------------------------------
+
+class _CorrelationTracker:
+    """Thread-safe FIFO queue mapping (task_id, tool_name) -> event_ids."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._pending: Dict[str, Deque[Tuple[str, float]]] = {}
+
+    def push(self, task_id: Optional[str], tool_name: str, event_id: str) -> None:
+        key = f"{task_id or ''}:{tool_name}"
+        with self._lock:
+            bucket = self._pending.setdefault(key, deque())
+            bucket.append((event_id, time.monotonic()))
+
+    def pop(self, task_id: Optional[str], tool_name: str) -> Optional[str]:
+        key = f"{task_id or ''}:{tool_name}"
+        now = time.monotonic()
+        with self._lock:
+            # Purge stale entries across all buckets opportunistically.
+            for k in list(self._pending):
+                q = self._pending[k]
+                while q and (now - q[0][1]) > _CORRELATION_TTL_S:
+                    q.popleft()
+                if not q:
+                    del self._pending[k]
+
+            bucket = self._pending.get(key)
+            if not bucket:
+                return None
+            event_id, _ = bucket.popleft()
+            if not bucket:
+                del self._pending[key]
+            return event_id
+
+
+# ---------------------------------------------------------------------------
+# Plugin registration entry-point
+# ---------------------------------------------------------------------------
+
+def register(ctx: Any) -> None:
+    """Hermes plugin entry-point — called once at startup."""
+
+    # Build config from Hermes settings + env vars.
+    raw_settings: Dict[str, Any] = {}
+    for field_name in (
+        "enabled", "endpoint", "auth_token", "timeout_ms", "timeout_policy",
+        "intercept", "skip", "notify",
+        "circuit_breaker_failure_threshold", "circuit_breaker_recovery_interval_ms",
+    ):
+        try:
+            val = ctx.get_setting(field_name)
+            if val is not None:
+                raw_settings[field_name] = val
+        except Exception:
+            pass
+
+    config = parse_config(raw_settings)
+
+    if not config.enabled:
+        logger.info("AgentShield plugin disabled")
+        return
+
+    client = AgentShieldClient(config)
+    breaker = CircuitBreaker(
+        failure_threshold=config.circuit_breaker_failure_threshold,
+        recovery_interval_ms=config.circuit_breaker_recovery_interval_ms,
+    )
+    skip_set = set(config.skip)
+    intercept_set = set(config.intercept) if config.intercept else None
+    correlation = _CorrelationTracker()
+
+    # ---- pre_tool_call: synchronous evaluation --------------------------
+
+    def _on_pre_tool_call(
+        tool_name: str,
+        args: Dict[str, Any],
+        task_id: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Optional[Dict[str, Any]]:
+        """Evaluate a tool call against the AgentShield engine.
+
+        Returns ``{"block": True, "reason": "..."}`` to prevent execution,
+        or ``None`` to allow.
+        """
+        canonical = normalise_tool_name(tool_name)
+
+        # Skip list takes precedence.
+        if tool_name in skip_set or canonical in skip_set:
+            return None
+
+        # If an intercept list is configured, only evaluate listed tools.
+        if intercept_set and tool_name not in intercept_set and canonical not in intercept_set:
+            return None
+
+        # Circuit breaker check.
+        if breaker.is_open():
+            logger.warning(
+                "AgentShield circuit breaker open, applying %s policy",
+                config.timeout_policy,
+            )
+            return _apply_timeout_policy(config.timeout_policy)
+
+        request = build_evaluation_request(
+            tool_name,
+            args if isinstance(args, dict) else {},
+            task_id=task_id,
+        )
+
+        try:
+            response = client.evaluate(request)
+            breaker.record_success()
+
+            effective_mode = response.get("effective_mode")
+            if effective_mode:
+                logger.debug(
+                    "AgentShield effective mode for %s: %s",
+                    tool_name,
+                    effective_mode,
+                )
+
+            # Log triage results.
+            for triage in response.get("triage_results") or []:
+                logger.info(
+                    "AgentShield triage: %s (%s) - %s",
+                    triage.get("verdict"),
+                    triage.get("confidence"),
+                    triage.get("reasoning"),
+                )
+
+            action = response.get("action", "allow")
+
+            if action == "block":
+                triage_reason = (response.get("triage_results") or [{}])[0].get("reasoning") if response.get("triage_results") else None
+                reason = response.get("reason") or "Blocked by AgentShield"
+                if triage_reason:
+                    reason = f"{reason} (Triage: {triage_reason})"
+
+                logger.warning("AgentShield blocked %s: %s", tool_name, reason)
+                msg = _format_alert_message(response, tool_name, "blocked", config.notify)
+                if msg:
+                    logger.warning(msg)
+
+                return {"block": True, "reason": reason}
+
+            if action == "require_approval":
+                reason = (
+                    response.get("reason")
+                    or "AgentShield requires explicit approval before this tool call can proceed"
+                )
+                logger.warning(
+                    "AgentShield requires approval for %s: %s",
+                    tool_name,
+                    reason,
+                )
+                msg = _format_alert_message(response, tool_name, "requires approval", config.notify)
+                if msg:
+                    logger.warning(msg)
+
+                return {"block": True, "reason": reason}
+
+            # High-confidence triage allow overrides rule alerts.
+            has_hc_allow = any(
+                t.get("verdict") == "allow" and (t.get("confidence") or 0) > 0.8
+                for t in (response.get("triage_results") or [])
+            )
+
+            if response.get("alerts") and has_hc_allow:
+                logger.info(
+                    "AgentShield: %d alert(s) for %s, but triage overrides with high-confidence allow",
+                    len(response["alerts"]),
+                    tool_name,
+                )
+            elif action == "log" and response.get("alerts"):
+                logger.info(
+                    "AgentShield logged %d alert(s) for %s",
+                    len(response["alerts"]),
+                    tool_name,
+                )
+                msg = _format_alert_message(response, tool_name, "logged", config.notify)
+                if msg:
+                    logger.warning(msg)
+
+            # Queue for post_tool_call correlation.
+            correlation.push(task_id, tool_name, request["event_id"])
+            return None  # allow
+
+        except Exception as exc:
+            breaker.record_failure()
+            logger.warning("AgentShield evaluation failed: %s", exc)
+            return _apply_timeout_policy(config.timeout_policy)
+
+    # ---- post_tool_call: fire-and-forget audit --------------------------
+
+    def _on_post_tool_call(
+        tool_name: str,
+        args: Dict[str, Any],
+        result: Any = None,
+        task_id: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Send a fire-and-forget audit report after tool execution."""
+        corr_id = correlation.pop(task_id, tool_name) or str(uuid.uuid4())
+
+        is_error = isinstance(result, str) and result.startswith("Error")
+        error_message = result if is_error else None
+
+        report = build_audit_report(
+            tool_name,
+            args if isinstance(args, dict) else {},
+            result,
+            correlation_id=corr_id,
+            task_id=task_id,
+            is_error=is_error,
+            error_message=error_message,
+        )
+        client.send_audit(report)
+
+    # ---- lifecycle hooks ------------------------------------------------
+
+    def _on_session_start(task_id: Optional[str] = None, **kwargs: Any) -> None:
+        event = build_lifecycle_event("session_start", task_id=task_id)
+        client.send_lifecycle(event)
+
+    def _on_session_end(task_id: Optional[str] = None, **kwargs: Any) -> None:
+        event = build_lifecycle_event("session_end", task_id=task_id)
+        client.send_lifecycle(event)
+
+    # ---- register hooks -------------------------------------------------
+
+    ctx.register_hook("pre_tool_call", _on_pre_tool_call)
+    ctx.register_hook("post_tool_call", _on_post_tool_call)
+    ctx.register_hook("on_session_start", _on_session_start)
+    ctx.register_hook("on_session_end", _on_session_end)
+
+    # Startup health check (non-blocking).
+    def _health_check() -> None:
+        try:
+            ok = client.health_check()
+            if ok:
+                logger.info("AgentShield reachable at %s", config.endpoint)
+            else:
+                logger.warning(
+                    "AgentShield not reachable at %s (will retry on first tool call)",
+                    config.endpoint,
+                )
+        except Exception:
+            logger.warning("AgentShield health check failed")
+
+    threading.Thread(target=_health_check, daemon=True).start()

--- a/plugins/hermes/circuit_breaker.py
+++ b/plugins/hermes/circuit_breaker.py
@@ -10,6 +10,7 @@ State machine::
 
 from __future__ import annotations
 
+import threading
 import time
 from typing import Literal
 
@@ -24,48 +25,44 @@ class CircuitBreaker:
         failure_threshold: int = 3,
         recovery_interval_ms: int = 30_000,
     ) -> None:
+        self._lock = threading.Lock()
         self._state: CircuitBreakerState = "closed"
         self._consecutive_failures: int = 0
         self._last_failure_time: float = 0.0
         self._failure_threshold = failure_threshold
         self._recovery_interval_s = recovery_interval_ms / 1000.0
 
-    # -- public API --------------------------------------------------------
-
     def is_open(self) -> bool:
         """Return *True* if calls should be skipped (circuit is open)."""
-        if self._state == "closed":
-            return False
-
-        if self._state == "open":
-            elapsed = time.monotonic() - self._last_failure_time
-            if elapsed >= self._recovery_interval_s:
-                self._state = "half-open"
-                return False  # allow a probe request
-            return True
-
-        # half-open: allow the probe request through
-        return False
+        with self._lock:
+            self._maybe_transition_to_half_open()
+            return self._state == "open"
 
     def record_success(self) -> None:
-        self._consecutive_failures = 0
-        self._state = "closed"
+        with self._lock:
+            self._consecutive_failures = 0
+            self._state = "closed"
 
     def record_failure(self) -> None:
-        self._consecutive_failures += 1
-        self._last_failure_time = time.monotonic()
+        with self._lock:
+            self._consecutive_failures += 1
+            self._last_failure_time = time.monotonic()
 
-        if self._state == "half-open":
-            self._state = "open"
-            return
+            if self._state == "half-open":
+                self._state = "open"
+                return
 
-        if self._consecutive_failures >= self._failure_threshold:
-            self._state = "open"
+            if self._consecutive_failures >= self._failure_threshold:
+                self._state = "open"
 
     def get_state(self) -> CircuitBreakerState:
-        # Re-evaluate open -> half-open transition on read.
+        with self._lock:
+            self._maybe_transition_to_half_open()
+            return self._state
+
+    def _maybe_transition_to_half_open(self) -> None:
+        """Promote open -> half-open if the recovery interval has elapsed."""
         if self._state == "open":
             elapsed = time.monotonic() - self._last_failure_time
             if elapsed >= self._recovery_interval_s:
                 self._state = "half-open"
-        return self._state

--- a/plugins/hermes/circuit_breaker.py
+++ b/plugins/hermes/circuit_breaker.py
@@ -1,0 +1,71 @@
+"""Three-state circuit breaker for the AgentShield HTTP client.
+
+State machine::
+
+    closed  --(N consecutive failures)--> open
+    open    --(recovery_interval_ms elapsed)--> half-open
+    half-open --(success)--> closed
+    half-open --(failure)--> open
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Literal
+
+CircuitBreakerState = Literal["closed", "open", "half-open"]
+
+
+class CircuitBreaker:
+    """Protects the agent loop from a slow or unavailable engine."""
+
+    def __init__(
+        self,
+        failure_threshold: int = 3,
+        recovery_interval_ms: int = 30_000,
+    ) -> None:
+        self._state: CircuitBreakerState = "closed"
+        self._consecutive_failures: int = 0
+        self._last_failure_time: float = 0.0
+        self._failure_threshold = failure_threshold
+        self._recovery_interval_s = recovery_interval_ms / 1000.0
+
+    # -- public API --------------------------------------------------------
+
+    def is_open(self) -> bool:
+        """Return *True* if calls should be skipped (circuit is open)."""
+        if self._state == "closed":
+            return False
+
+        if self._state == "open":
+            elapsed = time.monotonic() - self._last_failure_time
+            if elapsed >= self._recovery_interval_s:
+                self._state = "half-open"
+                return False  # allow a probe request
+            return True
+
+        # half-open: allow the probe request through
+        return False
+
+    def record_success(self) -> None:
+        self._consecutive_failures = 0
+        self._state = "closed"
+
+    def record_failure(self) -> None:
+        self._consecutive_failures += 1
+        self._last_failure_time = time.monotonic()
+
+        if self._state == "half-open":
+            self._state = "open"
+            return
+
+        if self._consecutive_failures >= self._failure_threshold:
+            self._state = "open"
+
+    def get_state(self) -> CircuitBreakerState:
+        # Re-evaluate open -> half-open transition on read.
+        if self._state == "open":
+            elapsed = time.monotonic() - self._last_failure_time
+            if elapsed >= self._recovery_interval_s:
+                self._state = "half-open"
+        return self._state

--- a/plugins/hermes/client.py
+++ b/plugins/hermes/client.py
@@ -1,0 +1,147 @@
+"""HTTP client for communicating with the AgentShield engine.
+
+Uses only the Python standard library (``urllib.request``) so the
+plugin has zero external dependencies beyond Hermes itself.
+
+- ``evaluate()`` is synchronous with a configurable timeout.
+- ``send_audit()`` and ``send_lifecycle()`` are fire-and-forget.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import urllib.error
+import urllib.request
+from typing import Any, Dict, Optional
+
+from .config import AgentShieldConfig
+
+logger = logging.getLogger("agentshield")
+
+CONTRACT_VERSION = "1.0.0"
+
+VALID_ACTIONS = {"allow", "block", "log", "require_approval"}
+
+
+class AgentShieldClient:
+    """HTTP client for the AgentShield real-time receiver."""
+
+    def __init__(self, config: AgentShieldConfig) -> None:
+        self._endpoint = config.endpoint
+        base_url = config.endpoint.rsplit("/evaluate", 1)[0]
+        self._audit_endpoint = f"{base_url}/audit"
+        self._lifecycle_endpoint = f"{base_url}/lifecycle"
+        self._health_endpoint = f"{base_url}/health"
+        self._feedback_endpoint = f"{base_url}/feedback"
+        self._override_endpoint = f"{base_url}/override"
+        self._timeout_s = config.timeout_ms / 1000.0
+        self._auth_token = config.auth_token
+
+    # -- synchronous evaluation -------------------------------------------
+
+    def evaluate(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        """POST an evaluation request and return the parsed response.
+
+        Raises on network errors or invalid responses so the caller
+        can feed the result to the circuit breaker.
+        """
+        body = self._post(self._endpoint, request, timeout=self._timeout_s)
+
+        action = body.get("action")
+        if not isinstance(action, str) or action not in VALID_ACTIONS:
+            raise ValueError(f"AgentShield returned invalid action: {action!r}")
+
+        return body
+
+    # -- fire-and-forget helpers ------------------------------------------
+
+    def send_audit(self, report: Dict[str, Any]) -> None:
+        self._fire_and_forget(self._audit_endpoint, report, "audit")
+
+    def send_lifecycle(self, event: Dict[str, Any]) -> None:
+        self._fire_and_forget(self._lifecycle_endpoint, event, "lifecycle")
+
+    def submit_feedback(
+        self,
+        event_id: str,
+        feedback_type: str,
+        comment: Optional[str] = None,
+    ) -> None:
+        from datetime import datetime, timezone
+
+        payload = {
+            "event_id": event_id,
+            "feedback_type": feedback_type,
+            "comment": comment,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        self._fire_and_forget(self._feedback_endpoint, payload, "feedback")
+
+    def send_override(self, session_id: str, event_id: str) -> None:
+        payload = {"session_id": session_id, "event_id": event_id}
+        self._fire_and_forget(self._override_endpoint, payload, "override")
+
+    def health_check(self) -> bool:
+        """Return *True* if the engine is reachable."""
+        try:
+            req = urllib.request.Request(self._health_endpoint, method="GET")
+            for key, val in self._build_headers().items():
+                req.add_unredirected_header(key, val)
+            with urllib.request.urlopen(req, timeout=2) as resp:
+                return 200 <= resp.status < 300
+        except Exception:
+            return False
+
+    # -- internal ---------------------------------------------------------
+
+    def _post(
+        self,
+        url: str,
+        payload: Dict[str, Any],
+        timeout: float,
+    ) -> Dict[str, Any]:
+        data = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(url, data=data, method="POST")
+        # Use add_unredirected_header to preserve exact header case
+        # (urllib's default add_header lowercases via .capitalize()).
+        for key, val in self._build_headers().items():
+            req.add_unredirected_header(key, val)
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                if resp.status < 200 or resp.status >= 300:
+                    raise urllib.error.HTTPError(
+                        url, resp.status, f"HTTP {resp.status}", resp.headers, None
+                    )
+                return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            raise RuntimeError(
+                f"AgentShield returned HTTP {exc.code}: {exc.reason}"
+            ) from exc
+
+    def _fire_and_forget(
+        self,
+        url: str,
+        payload: Dict[str, Any],
+        label: str,
+    ) -> None:
+        """POST in a background thread, swallowing errors."""
+
+        def _send() -> None:
+            try:
+                self._post(url, payload, timeout=5.0)
+            except Exception as exc:
+                logger.debug("AgentShield %s send failed: %s", label, exc)
+
+        thread = threading.Thread(target=_send, daemon=True)
+        thread.start()
+
+    def _build_headers(self) -> Dict[str, str]:
+        headers: Dict[str, str] = {
+            "Content-Type": "application/json; charset=utf-8",
+            "X-AgentShield-Version": CONTRACT_VERSION,
+        }
+        if self._auth_token:
+            headers["Authorization"] = f"Bearer {self._auth_token}"
+        return headers

--- a/plugins/hermes/client.py
+++ b/plugins/hermes/client.py
@@ -11,10 +11,11 @@ from __future__ import annotations
 
 import json
 import logging
+import queue
 import threading
 import urllib.error
 import urllib.request
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 from .config import AgentShieldConfig
 
@@ -37,7 +38,20 @@ class AgentShieldClient:
         self._feedback_endpoint = f"{base_url}/feedback"
         self._override_endpoint = f"{base_url}/override"
         self._timeout_s = config.timeout_ms / 1000.0
-        self._auth_token = config.auth_token
+
+        self._headers: Dict[str, str] = {
+            "Content-Type": "application/json; charset=utf-8",
+            "X-AgentShield-Version": CONTRACT_VERSION,
+        }
+        if config.auth_token:
+            self._headers["Authorization"] = f"Bearer {config.auth_token}"
+
+        # Bounded background queue for fire-and-forget requests.
+        self._bg_queue: queue.Queue[Tuple[str, Dict[str, Any], str]] = queue.Queue(
+            maxsize=256
+        )
+        self._bg_worker = threading.Thread(target=self._bg_loop, daemon=True)
+        self._bg_worker.start()
 
     # -- synchronous evaluation -------------------------------------------
 
@@ -87,7 +101,7 @@ class AgentShieldClient:
         """Return *True* if the engine is reachable."""
         try:
             req = urllib.request.Request(self._health_endpoint, method="GET")
-            for key, val in self._build_headers().items():
+            for key, val in self._headers.items():
                 req.add_unredirected_header(key, val)
             with urllib.request.urlopen(req, timeout=2) as resp:
                 return 200 <= resp.status < 300
@@ -104,9 +118,9 @@ class AgentShieldClient:
     ) -> Dict[str, Any]:
         data = json.dumps(payload).encode("utf-8")
         req = urllib.request.Request(url, data=data, method="POST")
-        # Use add_unredirected_header to preserve exact header case
-        # (urllib's default add_header lowercases via .capitalize()).
-        for key, val in self._build_headers().items():
+        # add_unredirected_header preserves exact header case
+        # (urllib's add_header lowercases via .capitalize()).
+        for key, val in self._headers.items():
             req.add_unredirected_header(key, val)
         try:
             with urllib.request.urlopen(req, timeout=timeout) as resp:
@@ -126,22 +140,17 @@ class AgentShieldClient:
         payload: Dict[str, Any],
         label: str,
     ) -> None:
-        """POST in a background thread, swallowing errors."""
+        """Enqueue a background POST, dropping silently if the queue is full."""
+        try:
+            self._bg_queue.put_nowait((url, payload, label))
+        except queue.Full:
+            logger.debug("AgentShield %s queue full, dropping", label)
 
-        def _send() -> None:
+    def _bg_loop(self) -> None:
+        """Background worker that drains the fire-and-forget queue."""
+        while True:
+            url, payload, label = self._bg_queue.get()
             try:
                 self._post(url, payload, timeout=5.0)
             except Exception as exc:
                 logger.debug("AgentShield %s send failed: %s", label, exc)
-
-        thread = threading.Thread(target=_send, daemon=True)
-        thread.start()
-
-    def _build_headers(self) -> Dict[str, str]:
-        headers: Dict[str, str] = {
-            "Content-Type": "application/json; charset=utf-8",
-            "X-AgentShield-Version": CONTRACT_VERSION,
-        }
-        if self._auth_token:
-            headers["Authorization"] = f"Bearer {self._auth_token}"
-        return headers

--- a/plugins/hermes/config.py
+++ b/plugins/hermes/config.py
@@ -1,0 +1,125 @@
+"""Configuration parsing and validation for the AgentShield Hermes plugin."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+
+VALID_TIMEOUT_POLICIES = {"allow", "block", "log"}
+VALID_NOTIFY_LEVELS = {"all", "high", "critical", "none"}
+
+DEFAULT_INTERCEPT: List[str] = [
+    "terminal",
+    "execute_command",
+    "write_file",
+    "create_file",
+    "edit_file",
+    "patch_file",
+    "read_file",
+    "web_browse",
+    "browser",
+    "send_message",
+    "delegate",
+    "spawn_agent",
+    "code_execute",
+    "python_execute",
+]
+
+DEFAULT_SKIP: List[str] = [
+    "todo",
+    "memory_search",
+    "memory_add",
+]
+
+
+@dataclass(frozen=True)
+class AgentShieldConfig:
+    """Validated configuration for the AgentShield plugin."""
+
+    enabled: bool = True
+    endpoint: str = "http://127.0.0.1:8433/api/v1/evaluate"
+    auth_token: str = ""
+    timeout_ms: int = 200
+    timeout_policy: str = "block"
+    intercept: List[str] = field(default_factory=lambda: list(DEFAULT_INTERCEPT))
+    skip: List[str] = field(default_factory=lambda: list(DEFAULT_SKIP))
+    notify: str = "high"
+    circuit_breaker_failure_threshold: int = 3
+    circuit_breaker_recovery_interval_ms: int = 30_000
+
+
+def parse_config(raw: Dict[str, Any] | None = None) -> AgentShieldConfig:
+    """Build a validated :class:`AgentShieldConfig` from raw settings.
+
+    Accepts the dict that Hermes passes via ``ctx.get_setting()`` calls
+    or a merged dict built during plugin registration.  Missing or
+    invalid values fall back to defaults.  The ``AGENTSHIELD_AUTH_TOKEN``
+    environment variable is used when no token is supplied in settings.
+    """
+    if not raw or not isinstance(raw, dict):
+        raw = {}
+
+    enabled = raw.get("enabled", True)
+    if not isinstance(enabled, bool):
+        enabled = True
+
+    endpoint = raw.get("endpoint", "")
+    if not isinstance(endpoint, str) or not endpoint.strip():
+        endpoint = AgentShieldConfig.endpoint
+    else:
+        endpoint = endpoint.strip()
+
+    # Auth token: setting > env var > empty
+    auth_token = raw.get("auth_token", "")
+    if not isinstance(auth_token, str) or not auth_token:
+        auth_token = os.environ.get("AGENTSHIELD_AUTH_TOKEN", "")
+
+    timeout_ms = raw.get("timeout_ms", 200)
+    if not isinstance(timeout_ms, (int, float)) or timeout_ms < 5 or timeout_ms > 5000:
+        timeout_ms = 200
+    timeout_ms = int(timeout_ms)
+
+    timeout_policy = raw.get("timeout_policy", "block")
+    if not isinstance(timeout_policy, str) or timeout_policy not in VALID_TIMEOUT_POLICIES:
+        timeout_policy = "block"
+
+    notify = raw.get("notify", "high")
+    if not isinstance(notify, str) or notify not in VALID_NOTIFY_LEVELS:
+        notify = "high"
+
+    intercept = raw.get("intercept", None)
+    if not isinstance(intercept, list):
+        intercept = list(DEFAULT_INTERCEPT)
+    else:
+        intercept = [s for s in intercept if isinstance(s, str) and s.strip()]
+
+    skip = raw.get("skip", None)
+    if not isinstance(skip, list):
+        skip = list(DEFAULT_SKIP)
+    else:
+        skip = [s for s in skip if isinstance(s, str) and s.strip()]
+
+    cb_threshold = raw.get("circuit_breaker_failure_threshold", 3)
+    if not isinstance(cb_threshold, (int, float)) or cb_threshold < 1:
+        cb_threshold = 3
+    cb_threshold = int(cb_threshold)
+
+    cb_recovery = raw.get("circuit_breaker_recovery_interval_ms", 30_000)
+    if not isinstance(cb_recovery, (int, float)) or cb_recovery < 1000:
+        cb_recovery = 30_000
+    cb_recovery = int(cb_recovery)
+
+    return AgentShieldConfig(
+        enabled=enabled,
+        endpoint=endpoint,
+        auth_token=auth_token,
+        timeout_ms=timeout_ms,
+        timeout_policy=timeout_policy,
+        intercept=intercept,
+        skip=skip,
+        notify=notify,
+        circuit_breaker_failure_threshold=cb_threshold,
+        circuit_breaker_recovery_interval_ms=cb_recovery,
+    )

--- a/plugins/hermes/event_builder.py
+++ b/plugins/hermes/event_builder.py
@@ -6,13 +6,31 @@ JSON contract (same wire format as the OpenClaw plugin).
 
 from __future__ import annotations
 
+import json
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 from .normalise import normalise_tool_call
 
 MAX_RESULT_SUMMARY_LENGTH = 1000
+
+
+def _base_envelope(
+    event_type: str,
+    *,
+    task_id: Optional[str] = None,
+    agent_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Common fields shared by all event payloads."""
+    return {
+        "event_id": str(uuid.uuid4()),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "event_type": event_type,
+        "source": "hermes",
+        "agent_id": agent_id,
+        "session_id": task_id,
+    }
 
 
 def build_evaluation_request(
@@ -21,27 +39,30 @@ def build_evaluation_request(
     *,
     task_id: Optional[str] = None,
     agent_id: Optional[str] = None,
+    canonical_name: Optional[str] = None,
+    command: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Build an ``EvaluationRequest`` payload for ``POST /api/v1/evaluate``."""
-    canonical, command = normalise_tool_call(tool_name, args)
+    """Build an ``EvaluationRequest`` payload for ``POST /api/v1/evaluate``.
+
+    If *canonical_name* and *command* are provided, normalization is skipped
+    (the caller already did it).
+    """
+    if canonical_name is None:
+        canonical_name, command = normalise_tool_call(tool_name, args)
 
     params = dict(args)
     if command:
         params["command"] = command
 
-    return {
-        "event_id": str(uuid.uuid4()),
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-        "event_type": "tool_call",
-        "tool_name": canonical,
-        "source": "hermes",
-        "command": command,
-        "params": params,
-        "agent_id": agent_id,
-        "session_id": task_id,
-        "working_dir": None,
-        "data": {},
-    }
+    envelope = _base_envelope("tool_call", task_id=task_id, agent_id=agent_id)
+    envelope.update(
+        tool_name=canonical_name,
+        command=command,
+        params=params,
+        working_dir=None,
+        data={},
+    )
+    return envelope
 
 
 def build_audit_report(
@@ -52,29 +73,30 @@ def build_audit_report(
     correlation_id: str,
     task_id: Optional[str] = None,
     agent_id: Optional[str] = None,
-    is_error: bool = False,
-    error_message: Optional[str] = None,
+    canonical_name: Optional[str] = None,
     duration_ms: float = 0,
 ) -> Dict[str, Any]:
-    """Build an ``AuditReport`` payload for ``POST /api/v1/audit``."""
-    canonical, _ = normalise_tool_call(tool_name, args)
+    """Build an ``AuditReport`` payload for ``POST /api/v1/audit``.
 
-    return {
-        "event_id": str(uuid.uuid4()),
-        "correlation_id": correlation_id,
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-        "event_type": "tool_result",
-        "tool_name": canonical,
-        "source": "hermes",
-        "result_summary": _summarise_result(result),
-        "is_error": is_error,
-        "error_message": error_message,
-        "duration_ms": duration_ms,
-        "agent_id": agent_id,
-        "session_id": task_id,
-        "working_dir": None,
-        "data": {},
-    }
+    Error status is derived from *result* automatically.
+    """
+    if canonical_name is None:
+        canonical_name, _ = normalise_tool_call(tool_name, args)
+
+    is_error = isinstance(result, str) and result.startswith("Error")
+
+    envelope = _base_envelope("tool_result", task_id=task_id, agent_id=agent_id)
+    envelope.update(
+        correlation_id=correlation_id,
+        tool_name=canonical_name,
+        result_summary=_summarise_result(result),
+        is_error=is_error,
+        error_message=result if is_error else None,
+        duration_ms=duration_ms,
+        working_dir=None,
+        data={},
+    )
+    return envelope
 
 
 def build_lifecycle_event(
@@ -85,15 +107,9 @@ def build_lifecycle_event(
     data: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Build a ``LifecycleEvent`` payload for ``POST /api/v1/lifecycle``."""
-    return {
-        "event_id": str(uuid.uuid4()),
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-        "event_type": event_type,
-        "source": "hermes",
-        "agent_id": agent_id,
-        "session_id": task_id,
-        "data": data or {},
-    }
+    envelope = _base_envelope(event_type, task_id=task_id, agent_id=agent_id)
+    envelope["data"] = data or {}
+    return envelope
 
 
 def _summarise_result(result: Any) -> Optional[str]:
@@ -104,8 +120,6 @@ def _summarise_result(result: Any) -> Optional[str]:
         text = result
     else:
         try:
-            import json
-
             text = json.dumps(result)
         except (TypeError, ValueError):
             text = str(result)

--- a/plugins/hermes/event_builder.py
+++ b/plugins/hermes/event_builder.py
@@ -1,0 +1,116 @@
+"""Build evaluation requests, audit reports, and lifecycle events.
+
+Translates Hermes hook parameters into the AgentShield engine's
+JSON contract (same wire format as the OpenClaw plugin).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from .normalise import normalise_tool_call
+
+MAX_RESULT_SUMMARY_LENGTH = 1000
+
+
+def build_evaluation_request(
+    tool_name: str,
+    args: Dict[str, Any],
+    *,
+    task_id: Optional[str] = None,
+    agent_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build an ``EvaluationRequest`` payload for ``POST /api/v1/evaluate``."""
+    canonical, command = normalise_tool_call(tool_name, args)
+
+    params = dict(args)
+    if command:
+        params["command"] = command
+
+    return {
+        "event_id": str(uuid.uuid4()),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "event_type": "tool_call",
+        "tool_name": canonical,
+        "source": "hermes",
+        "command": command,
+        "params": params,
+        "agent_id": agent_id,
+        "session_id": task_id,
+        "working_dir": None,
+        "data": {},
+    }
+
+
+def build_audit_report(
+    tool_name: str,
+    args: Dict[str, Any],
+    result: Any,
+    *,
+    correlation_id: str,
+    task_id: Optional[str] = None,
+    agent_id: Optional[str] = None,
+    is_error: bool = False,
+    error_message: Optional[str] = None,
+    duration_ms: float = 0,
+) -> Dict[str, Any]:
+    """Build an ``AuditReport`` payload for ``POST /api/v1/audit``."""
+    canonical, _ = normalise_tool_call(tool_name, args)
+
+    return {
+        "event_id": str(uuid.uuid4()),
+        "correlation_id": correlation_id,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "event_type": "tool_result",
+        "tool_name": canonical,
+        "source": "hermes",
+        "result_summary": _summarise_result(result),
+        "is_error": is_error,
+        "error_message": error_message,
+        "duration_ms": duration_ms,
+        "agent_id": agent_id,
+        "session_id": task_id,
+        "working_dir": None,
+        "data": {},
+    }
+
+
+def build_lifecycle_event(
+    event_type: str,
+    *,
+    task_id: Optional[str] = None,
+    agent_id: Optional[str] = None,
+    data: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Build a ``LifecycleEvent`` payload for ``POST /api/v1/lifecycle``."""
+    return {
+        "event_id": str(uuid.uuid4()),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "event_type": event_type,
+        "source": "hermes",
+        "agent_id": agent_id,
+        "session_id": task_id,
+        "data": data or {},
+    }
+
+
+def _summarise_result(result: Any) -> Optional[str]:
+    if result is None:
+        return None
+
+    if isinstance(result, str):
+        text = result
+    else:
+        try:
+            import json
+
+            text = json.dumps(result)
+        except (TypeError, ValueError):
+            text = str(result)
+
+    if len(text) > MAX_RESULT_SUMMARY_LENGTH:
+        return text[:MAX_RESULT_SUMMARY_LENGTH]
+
+    return text

--- a/plugins/hermes/normalise.py
+++ b/plugins/hermes/normalise.py
@@ -107,14 +107,8 @@ def _build_command(
         cmd = args.get("command") or args.get("cmd")
         return str(cmd) if cmd else None
 
-    if canonical == "write":
-        return f"Write: {_file_path(args)}"
-
-    if canonical == "read":
-        return f"Read: {_file_path(args)}"
-
-    if canonical == "edit":
-        return f"Edit: {_file_path(args)}"
+    if canonical in ("write", "read", "edit"):
+        return f"{canonical.capitalize()}: {_file_path(args)}"
 
     if canonical == "browser":
         action = _str(args.get("action", "navigate"))
@@ -133,7 +127,6 @@ def _build_command(
 
     if canonical == "code_execute":
         code = _str(args.get("code") or args.get("script", ""))
-        # Truncate for readability; full code goes in params
         if len(code) > 200:
             code = code[:200] + "..."
         return f"Execute: {code}" if code else None

--- a/plugins/hermes/normalise.py
+++ b/plugins/hermes/normalise.py
@@ -1,0 +1,159 @@
+"""Map Hermes tool names and parameters to AgentShield canonical forms.
+
+Hermes ships 40+ built-in tools whose names vary from those used by
+OpenClaw.  This module normalises both the *tool name* (so Sigma rules
+can match regardless of platform) and a *command string* that provides
+human-readable context for the detection engine.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Tuple
+
+# Hermes tool name -> AgentShield canonical name
+_TOOL_ALIASES: Dict[str, str] = {
+    # Terminal / exec
+    "terminal": "exec",
+    "execute_command": "exec",
+    "run_command": "exec",
+    "shell": "exec",
+    # File write
+    "write_file": "write",
+    "create_file": "write",
+    "save_file": "write",
+    # File read
+    "read_file": "read",
+    "view_file": "read",
+    # File edit
+    "edit_file": "edit",
+    "patch_file": "edit",
+    "replace_in_file": "edit",
+    # Browser
+    "web_browse": "browser",
+    "browser": "browser",
+    "navigate": "browser",
+    "browse_url": "browser",
+    # Messaging
+    "send_message": "message",
+    "telegram_send": "message",
+    "discord_send": "message",
+    "slack_send": "message",
+    "whatsapp_send": "message",
+    "signal_send": "message",
+    # Agent delegation
+    "delegate": "sessions_spawn",
+    "spawn_agent": "sessions_spawn",
+    "create_subagent": "sessions_spawn",
+    # Code execution
+    "code_execute": "code_execute",
+    "python_execute": "code_execute",
+    "run_python": "code_execute",
+    # Web search
+    "web_search": "web_search",
+    "search": "web_search",
+    # Image generation
+    "image_generate": "image_generate",
+    "generate_image": "image_generate",
+    # Vision
+    "vision": "vision",
+    "analyze_image": "vision",
+    # TTS
+    "text_to_speech": "tts",
+    "tts": "tts",
+    # Memory
+    "memory_add": "memory",
+    "memory_search": "memory",
+    "memory_delete": "memory",
+    # Task planning
+    "task_plan": "planning",
+    "todo": "planning",
+    # Cron
+    "cron_add": "cron",
+    "cron_remove": "cron",
+    "cron_list": "cron",
+}
+
+
+def normalise_tool_name(hermes_name: str) -> str:
+    """Return the AgentShield canonical name for a Hermes tool.
+
+    Unknown tools pass through unchanged.
+    """
+    return _TOOL_ALIASES.get(hermes_name, hermes_name)
+
+
+def normalise_tool_call(
+    tool_name: str,
+    args: Dict[str, Any],
+) -> Tuple[str, Optional[str]]:
+    """Normalise a Hermes tool call into (canonical_name, command_string).
+
+    Returns the canonical tool name and a human-readable command string
+    that the AgentShield engine uses for Sigma rule field matching.
+    """
+    canonical = normalise_tool_name(tool_name)
+
+    command = _build_command(canonical, tool_name, args)
+    return canonical, command
+
+
+def _build_command(
+    canonical: str,
+    original: str,
+    args: Dict[str, Any],
+) -> Optional[str]:
+    """Build a command string from the canonical name and args."""
+    if canonical == "exec":
+        cmd = args.get("command") or args.get("cmd")
+        return str(cmd) if cmd else None
+
+    if canonical == "write":
+        return f"Write: {_file_path(args)}"
+
+    if canonical == "read":
+        return f"Read: {_file_path(args)}"
+
+    if canonical == "edit":
+        return f"Edit: {_file_path(args)}"
+
+    if canonical == "browser":
+        action = _str(args.get("action", "navigate"))
+        url = _str(args.get("url", ""))
+        return f"{action}: {url}".strip()
+
+    if canonical == "message":
+        # Hermes messaging tools embed the platform in the tool name
+        channel = _str(args.get("channel") or args.get("chat_id") or args.get("to", ""))
+        platform = original.replace("_send", "").replace("send_", "")
+        return f"Message to {channel}" if channel else f"Message via {platform}"
+
+    if canonical == "sessions_spawn":
+        agent = _str(args.get("agent_id") or args.get("agent") or args.get("task", ""))
+        return f"Spawn: {agent}" if agent else "Spawn: <unknown>"
+
+    if canonical == "code_execute":
+        code = _str(args.get("code") or args.get("script", ""))
+        # Truncate for readability; full code goes in params
+        if len(code) > 200:
+            code = code[:200] + "..."
+        return f"Execute: {code}" if code else None
+
+    if canonical == "web_search":
+        query = _str(args.get("query") or args.get("q", ""))
+        return f"Search: {query}" if query else None
+
+    # Fallback: use original tool name
+    return original
+
+
+def _file_path(args: Dict[str, Any]) -> str:
+    """Extract file path from various Hermes arg styles."""
+    for key in ("path", "file_path", "filepath", "filename", "file"):
+        val = args.get(key)
+        if isinstance(val, str) and val:
+            return val
+    return "<unknown>"
+
+
+def _str(value: Any) -> str:
+    return str(value) if value is not None else ""

--- a/plugins/hermes/plugin.yaml
+++ b/plugins/hermes/plugin.yaml
@@ -1,0 +1,84 @@
+name: agentshield
+version: 1.0.0
+description: >-
+  Real-time security evaluation for Hermes agent tool calls.
+  Evaluates every tool invocation against AgentShield's Sigma-based
+  detection engine and blocks, requires approval, or logs threats.
+author: AgentShield
+homepage: https://github.com/agentshield-ai/agentshield
+
+provides_tools: []
+provides_hooks:
+  - pre_tool_call
+  - post_tool_call
+  - on_session_start
+  - on_session_end
+
+requires_env:
+  - name: AGENTSHIELD_AUTH_TOKEN
+    prompt: "AgentShield API bearer token (leave blank for local dev)"
+    required: false
+    category: security
+
+settings:
+  enabled:
+    type: bool
+    default: true
+    description: Enable or disable the AgentShield plugin
+
+  endpoint:
+    type: string
+    default: "http://127.0.0.1:8433/api/v1/evaluate"
+    description: AgentShield engine evaluate endpoint URL
+
+  timeout_ms:
+    type: int
+    default: 200
+    description: HTTP timeout in milliseconds for evaluation calls (5-5000)
+
+  timeout_policy:
+    type: string
+    default: block
+    description: "Policy when engine is unreachable: allow, block, or log"
+
+  notify:
+    type: string
+    default: high
+    description: "Minimum severity for user notifications: all, high, critical, none"
+
+  intercept:
+    type: list
+    default:
+      - terminal
+      - execute_command
+      - write_file
+      - create_file
+      - edit_file
+      - patch_file
+      - read_file
+      - web_browse
+      - browser
+      - send_message
+      - delegate
+      - spawn_agent
+      - code_execute
+      - python_execute
+    description: Tool names to intercept for security evaluation
+
+  skip:
+    type: list
+    default:
+      - todo
+      - memory_search
+      - memory_add
+    description: Tool names to always skip
+
+  circuit_breaker_failure_threshold:
+    type: int
+    default: 3
+    description: Consecutive failures before circuit opens
+
+  circuit_breaker_recovery_interval_ms:
+    type: int
+    default: 30000
+    description: Milliseconds before retrying after circuit opens

--- a/plugins/hermes/tests/conftest.py
+++ b/plugins/hermes/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Shared fixtures for AgentShield Hermes plugin tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure the plugin package is importable regardless of working directory.
+_PLUGIN_ROOT = Path(__file__).resolve().parent.parent
+if str(_PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PLUGIN_ROOT.parent))

--- a/plugins/hermes/tests/test_circuit_breaker.py
+++ b/plugins/hermes/tests/test_circuit_breaker.py
@@ -34,7 +34,7 @@ class TestCircuitBreaker:
         cb.record_failure()
         cb.record_success()
 
-        # Counter reset — need 3 more to trip.
+        # Counter reset -- need 3 more to trip.
         cb.record_failure()
         cb.record_failure()
         assert cb.get_state() == "closed"
@@ -49,7 +49,6 @@ class TestCircuitBreaker:
         assert cb.get_state() == "open"
         assert cb.is_open() is True
 
-        # Advance past recovery interval.
         with patch.object(time, "monotonic", return_value=time.monotonic() + 31):
             assert cb.is_open() is False
             assert cb.get_state() == "half-open"
@@ -79,5 +78,4 @@ class TestCircuitBreaker:
         cb = CircuitBreaker(failure_threshold=1, recovery_interval_ms=30_000)
         cb.record_failure()
         assert cb.is_open() is True
-        # Not enough time has passed.
         assert cb.is_open() is True

--- a/plugins/hermes/tests/test_circuit_breaker.py
+++ b/plugins/hermes/tests/test_circuit_breaker.py
@@ -1,0 +1,83 @@
+"""Tests for the circuit breaker module."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+from hermes.circuit_breaker import CircuitBreaker
+
+
+class TestCircuitBreaker:
+    def test_starts_in_closed_state(self) -> None:
+        cb = CircuitBreaker(failure_threshold=3, recovery_interval_ms=30_000)
+        assert cb.get_state() == "closed"
+        assert cb.is_open() is False
+
+    def test_transitions_to_open_after_threshold_failures(self) -> None:
+        cb = CircuitBreaker(failure_threshold=3, recovery_interval_ms=30_000)
+
+        cb.record_failure()
+        assert cb.get_state() == "closed"
+
+        cb.record_failure()
+        assert cb.get_state() == "closed"
+
+        cb.record_failure()
+        assert cb.get_state() == "open"
+        assert cb.is_open() is True
+
+    def test_resets_failure_count_on_success(self) -> None:
+        cb = CircuitBreaker(failure_threshold=3, recovery_interval_ms=30_000)
+
+        cb.record_failure()
+        cb.record_failure()
+        cb.record_success()
+
+        # Counter reset — need 3 more to trip.
+        cb.record_failure()
+        cb.record_failure()
+        assert cb.get_state() == "closed"
+
+        cb.record_failure()
+        assert cb.get_state() == "open"
+
+    def test_transitions_open_to_half_open_after_recovery(self) -> None:
+        cb = CircuitBreaker(failure_threshold=1, recovery_interval_ms=30_000)
+
+        cb.record_failure()
+        assert cb.get_state() == "open"
+        assert cb.is_open() is True
+
+        # Advance past recovery interval.
+        with patch.object(time, "monotonic", return_value=time.monotonic() + 31):
+            assert cb.is_open() is False
+            assert cb.get_state() == "half-open"
+
+    def test_half_open_to_closed_on_success(self) -> None:
+        cb = CircuitBreaker(failure_threshold=1, recovery_interval_ms=30_000)
+        cb.record_failure()
+
+        with patch.object(time, "monotonic", return_value=time.monotonic() + 31):
+            assert cb.is_open() is False  # half-open, probe allowed
+
+        cb.record_success()
+        assert cb.get_state() == "closed"
+
+    def test_half_open_to_open_on_failure(self) -> None:
+        cb = CircuitBreaker(failure_threshold=1, recovery_interval_ms=30_000)
+        cb.record_failure()
+
+        with patch.object(time, "monotonic", return_value=time.monotonic() + 31):
+            assert cb.is_open() is False  # half-open
+
+        cb.record_failure()
+        assert cb.get_state() == "open"
+        assert cb.is_open() is True
+
+    def test_remains_open_before_recovery_interval(self) -> None:
+        cb = CircuitBreaker(failure_threshold=1, recovery_interval_ms=30_000)
+        cb.record_failure()
+        assert cb.is_open() is True
+        # Not enough time has passed.
+        assert cb.is_open() is True

--- a/plugins/hermes/tests/test_client.py
+++ b/plugins/hermes/tests/test_client.py
@@ -1,0 +1,133 @@
+"""Tests for the AgentShield HTTP client."""
+
+from __future__ import annotations
+
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from threading import Thread
+from typing import Any, Dict, List
+
+import pytest
+
+from hermes.client import AgentShieldClient
+from hermes.config import AgentShieldConfig
+
+
+class _Handler(BaseHTTPRequestHandler):
+    """Minimal HTTP handler that records requests and returns canned responses."""
+
+    responses: List[Dict[str, Any]] = []
+    requests: List[Dict[str, Any]] = []
+    status_code: int = 200
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", 0))
+        body = json.loads(self.rfile.read(length)) if length else {}
+        # Build a case-insensitive header dict for test assertions.
+        hdrs = {k.lower(): v for k, v in self.headers.items()}
+        _Handler.requests.append({"path": self.path, "body": body, "headers": hdrs})
+
+        if _Handler.responses:
+            resp = _Handler.responses.pop(0)
+        else:
+            resp = {"action": "allow", "event_id": "test-id"}
+
+        self.send_response(_Handler.status_code)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(resp).encode())
+
+    def do_GET(self) -> None:
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b'{"status": "ok"}')
+
+    def log_message(self, *args: Any) -> None:
+        pass  # Suppress request logs during tests
+
+
+@pytest.fixture()
+def server():
+    """Start a local HTTP server for testing."""
+    _Handler.responses = []
+    _Handler.requests = []
+    _Handler.status_code = 200
+
+    srv = HTTPServer(("127.0.0.1", 0), _Handler)
+    port = srv.server_address[1]
+    thread = Thread(target=srv.serve_forever, daemon=True)
+    thread.start()
+    yield port
+    srv.shutdown()
+
+
+def _make_client(port: int, auth_token: str = "") -> AgentShieldClient:
+    config = AgentShieldConfig(
+        endpoint=f"http://127.0.0.1:{port}/api/v1/evaluate",
+        auth_token=auth_token,
+        timeout_ms=2000,
+    )
+    return AgentShieldClient(config)
+
+
+class TestEvaluate:
+    def test_returns_allow(self, server: int) -> None:
+        _Handler.responses = [{"action": "allow", "event_id": "e1"}]
+        client = _make_client(server)
+
+        result = client.evaluate({"event_id": "e1", "tool_name": "exec"})
+        assert result["action"] == "allow"
+
+    def test_returns_block(self, server: int) -> None:
+        _Handler.responses = [{"action": "block", "event_id": "e2", "reason": "dangerous"}]
+        client = _make_client(server)
+
+        result = client.evaluate({"event_id": "e2", "tool_name": "exec"})
+        assert result["action"] == "block"
+        assert result["reason"] == "dangerous"
+
+    def test_sends_auth_header(self, server: int) -> None:
+        _Handler.responses = [{"action": "allow", "event_id": "e3"}]
+        client = _make_client(server, auth_token="secret-token")
+
+        client.evaluate({"event_id": "e3", "tool_name": "exec"})
+
+        assert len(_Handler.requests) == 1
+        assert _Handler.requests[0]["headers"].get("authorization") == "Bearer secret-token"
+
+    def test_sends_version_header(self, server: int) -> None:
+        _Handler.responses = [{"action": "allow", "event_id": "e4"}]
+        client = _make_client(server)
+
+        client.evaluate({"event_id": "e4"})
+
+        assert _Handler.requests[0]["headers"].get("x-agentshield-version") == "1.0.0"
+
+    def test_raises_on_invalid_action(self, server: int) -> None:
+        _Handler.responses = [{"action": "explode", "event_id": "e5"}]
+        client = _make_client(server)
+
+        with pytest.raises(ValueError, match="invalid action"):
+            client.evaluate({"event_id": "e5"})
+
+    def test_raises_on_http_error(self, server: int) -> None:
+        _Handler.status_code = 500
+        _Handler.responses = [{"error": "internal"}]
+        client = _make_client(server)
+
+        with pytest.raises(RuntimeError, match="HTTP 500"):
+            client.evaluate({"event_id": "e6"})
+
+
+class TestHealthCheck:
+    def test_returns_true_when_healthy(self, server: int) -> None:
+        client = _make_client(server)
+        assert client.health_check() is True
+
+    def test_returns_false_on_unreachable(self) -> None:
+        config = AgentShieldConfig(
+            endpoint="http://127.0.0.1:1/api/v1/evaluate",
+            timeout_ms=100,
+        )
+        client = AgentShieldClient(config)
+        assert client.health_check() is False

--- a/plugins/hermes/tests/test_config.py
+++ b/plugins/hermes/tests/test_config.py
@@ -1,0 +1,85 @@
+"""Tests for config parsing and validation."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+from hermes.config import AgentShieldConfig, parse_config
+
+
+class TestParseConfig:
+    def test_defaults_when_no_input(self) -> None:
+        cfg = parse_config(None)
+        assert cfg.enabled is True
+        assert cfg.endpoint == "http://127.0.0.1:8433/api/v1/evaluate"
+        assert cfg.timeout_ms == 200
+        assert cfg.timeout_policy == "block"
+        assert cfg.notify == "high"
+        assert cfg.circuit_breaker_failure_threshold == 3
+        assert cfg.circuit_breaker_recovery_interval_ms == 30_000
+
+    def test_defaults_when_empty_dict(self) -> None:
+        cfg = parse_config({})
+        assert cfg.enabled is True
+        assert "terminal" in cfg.intercept
+
+    def test_override_values(self) -> None:
+        cfg = parse_config({
+            "enabled": False,
+            "endpoint": "http://remote:9000/api/v1/evaluate",
+            "timeout_ms": 500,
+            "timeout_policy": "allow",
+            "notify": "critical",
+            "intercept": ["terminal", "write_file"],
+            "skip": ["read_file"],
+            "circuit_breaker_failure_threshold": 5,
+            "circuit_breaker_recovery_interval_ms": 60_000,
+        })
+        assert cfg.enabled is False
+        assert cfg.endpoint == "http://remote:9000/api/v1/evaluate"
+        assert cfg.timeout_ms == 500
+        assert cfg.timeout_policy == "allow"
+        assert cfg.notify == "critical"
+        assert cfg.intercept == ["terminal", "write_file"]
+        assert cfg.skip == ["read_file"]
+        assert cfg.circuit_breaker_failure_threshold == 5
+        assert cfg.circuit_breaker_recovery_interval_ms == 60_000
+
+    def test_invalid_timeout_ms_falls_back_to_default(self) -> None:
+        cfg = parse_config({"timeout_ms": 999_999})
+        assert cfg.timeout_ms == 200
+
+    def test_invalid_timeout_ms_too_low(self) -> None:
+        cfg = parse_config({"timeout_ms": 1})
+        assert cfg.timeout_ms == 200
+
+    def test_invalid_timeout_policy_falls_back(self) -> None:
+        cfg = parse_config({"timeout_policy": "explode"})
+        assert cfg.timeout_policy == "block"
+
+    def test_invalid_notify_falls_back(self) -> None:
+        cfg = parse_config({"notify": "banana"})
+        assert cfg.notify == "high"
+
+    def test_auth_token_from_env(self) -> None:
+        with patch.dict(os.environ, {"AGENTSHIELD_AUTH_TOKEN": "secret123"}):
+            cfg = parse_config({})
+            assert cfg.auth_token == "secret123"
+
+    def test_auth_token_setting_overrides_env(self) -> None:
+        with patch.dict(os.environ, {"AGENTSHIELD_AUTH_TOKEN": "from-env"}):
+            cfg = parse_config({"auth_token": "from-setting"})
+            assert cfg.auth_token == "from-setting"
+
+    def test_intercept_filters_bad_values(self) -> None:
+        cfg = parse_config({"intercept": ["terminal", 123, "", None, "write_file"]})
+        assert cfg.intercept == ["terminal", "write_file"]
+
+    def test_circuit_breaker_threshold_too_low(self) -> None:
+        cfg = parse_config({"circuit_breaker_failure_threshold": 0})
+        assert cfg.circuit_breaker_failure_threshold == 3
+
+    def test_circuit_breaker_recovery_too_low(self) -> None:
+        cfg = parse_config({"circuit_breaker_recovery_interval_ms": 100})
+        assert cfg.circuit_breaker_recovery_interval_ms == 30_000

--- a/plugins/hermes/tests/test_event_builder.py
+++ b/plugins/hermes/tests/test_event_builder.py
@@ -24,7 +24,6 @@ class TestBuildEvaluationRequest:
         assert req["command"] == "ls -la"
         assert req["session_id"] == "session-1"
         assert req["params"]["command"] == "ls -la"
-        # event_id should be a valid UUID
         uuid.UUID(req["event_id"])
 
     def test_write_file_request(self) -> None:
@@ -49,10 +48,19 @@ class TestBuildEvaluationRequest:
 
     def test_timestamp_is_iso_format(self) -> None:
         req = build_evaluation_request("terminal", {"command": "date"})
-        # Should not raise
         from datetime import datetime
 
         datetime.fromisoformat(req["timestamp"])
+
+    def test_skips_normalization_when_canonical_provided(self) -> None:
+        req = build_evaluation_request(
+            "terminal",
+            {"command": "ls"},
+            canonical_name="exec",
+            command="ls",
+        )
+        assert req["tool_name"] == "exec"
+        assert req["command"] == "ls"
 
 
 class TestBuildAuditReport:
@@ -71,17 +79,25 @@ class TestBuildAuditReport:
         assert report["is_error"] is False
         assert report["result_summary"] == "file1.txt\nfile2.txt"
 
-    def test_error_report(self) -> None:
+    def test_error_detected_from_result(self) -> None:
         report = build_audit_report(
             "terminal",
             {"command": "bad-cmd"},
-            None,
+            "Error: command not found",
             correlation_id="corr-456",
-            is_error=True,
-            error_message="command not found",
         )
         assert report["is_error"] is True
-        assert report["error_message"] == "command not found"
+        assert report["error_message"] == "Error: command not found"
+
+    def test_non_error_result(self) -> None:
+        report = build_audit_report(
+            "terminal",
+            {"command": "echo hi"},
+            "hi",
+            correlation_id="corr-789",
+        )
+        assert report["is_error"] is False
+        assert report["error_message"] is None
 
     def test_result_summary_truncation(self) -> None:
         long_result = "x" * 2000
@@ -102,6 +118,16 @@ class TestBuildAuditReport:
             correlation_id="corr-000",
         )
         assert report["result_summary"] is None
+
+    def test_skips_normalization_when_canonical_provided(self) -> None:
+        report = build_audit_report(
+            "terminal",
+            {"command": "ls"},
+            "ok",
+            correlation_id="corr-111",
+            canonical_name="exec",
+        )
+        assert report["tool_name"] == "exec"
 
 
 class TestBuildLifecycleEvent:

--- a/plugins/hermes/tests/test_event_builder.py
+++ b/plugins/hermes/tests/test_event_builder.py
@@ -1,0 +1,125 @@
+"""Tests for event builder functions."""
+
+from __future__ import annotations
+
+import uuid
+
+from hermes.event_builder import (
+    build_audit_report,
+    build_evaluation_request,
+    build_lifecycle_event,
+)
+
+
+class TestBuildEvaluationRequest:
+    def test_basic_exec_request(self) -> None:
+        req = build_evaluation_request(
+            "terminal",
+            {"command": "ls -la"},
+            task_id="session-1",
+        )
+        assert req["event_type"] == "tool_call"
+        assert req["tool_name"] == "exec"
+        assert req["source"] == "hermes"
+        assert req["command"] == "ls -la"
+        assert req["session_id"] == "session-1"
+        assert req["params"]["command"] == "ls -la"
+        # event_id should be a valid UUID
+        uuid.UUID(req["event_id"])
+
+    def test_write_file_request(self) -> None:
+        req = build_evaluation_request(
+            "write_file",
+            {"path": "/tmp/test.txt", "content": "hello"},
+        )
+        assert req["tool_name"] == "write"
+        assert req["command"] == "Write: /tmp/test.txt"
+
+    def test_optional_agent_id(self) -> None:
+        req = build_evaluation_request(
+            "terminal",
+            {"command": "echo hi"},
+            agent_id="agent-42",
+        )
+        assert req["agent_id"] == "agent-42"
+
+    def test_no_task_id(self) -> None:
+        req = build_evaluation_request("terminal", {"command": "pwd"})
+        assert req["session_id"] is None
+
+    def test_timestamp_is_iso_format(self) -> None:
+        req = build_evaluation_request("terminal", {"command": "date"})
+        # Should not raise
+        from datetime import datetime
+
+        datetime.fromisoformat(req["timestamp"])
+
+
+class TestBuildAuditReport:
+    def test_basic_report(self) -> None:
+        report = build_audit_report(
+            "terminal",
+            {"command": "ls"},
+            "file1.txt\nfile2.txt",
+            correlation_id="corr-123",
+            task_id="session-1",
+        )
+        assert report["event_type"] == "tool_result"
+        assert report["tool_name"] == "exec"
+        assert report["source"] == "hermes"
+        assert report["correlation_id"] == "corr-123"
+        assert report["is_error"] is False
+        assert report["result_summary"] == "file1.txt\nfile2.txt"
+
+    def test_error_report(self) -> None:
+        report = build_audit_report(
+            "terminal",
+            {"command": "bad-cmd"},
+            None,
+            correlation_id="corr-456",
+            is_error=True,
+            error_message="command not found",
+        )
+        assert report["is_error"] is True
+        assert report["error_message"] == "command not found"
+
+    def test_result_summary_truncation(self) -> None:
+        long_result = "x" * 2000
+        report = build_audit_report(
+            "terminal",
+            {"command": "cat bigfile"},
+            long_result,
+            correlation_id="corr-789",
+        )
+        assert report["result_summary"] is not None
+        assert len(report["result_summary"]) == 1000
+
+    def test_none_result(self) -> None:
+        report = build_audit_report(
+            "terminal",
+            {"command": "true"},
+            None,
+            correlation_id="corr-000",
+        )
+        assert report["result_summary"] is None
+
+
+class TestBuildLifecycleEvent:
+    def test_session_start(self) -> None:
+        event = build_lifecycle_event("session_start", task_id="sess-1")
+        assert event["event_type"] == "session_start"
+        assert event["source"] == "hermes"
+        assert event["session_id"] == "sess-1"
+        uuid.UUID(event["event_id"])
+
+    def test_custom_data(self) -> None:
+        event = build_lifecycle_event(
+            "session_end",
+            task_id="sess-1",
+            data={"message_count": 42},
+        )
+        assert event["data"]["message_count"] == 42
+
+    def test_no_data_defaults_to_empty(self) -> None:
+        event = build_lifecycle_event("agent_start")
+        assert event["data"] == {}

--- a/plugins/hermes/tests/test_normalise.py
+++ b/plugins/hermes/tests/test_normalise.py
@@ -1,0 +1,125 @@
+"""Tests for tool name and command normalisation."""
+
+from __future__ import annotations
+
+from hermes.normalise import normalise_tool_call, normalise_tool_name
+
+
+class TestNormaliseToolName:
+    def test_terminal_maps_to_exec(self) -> None:
+        assert normalise_tool_name("terminal") == "exec"
+
+    def test_execute_command_maps_to_exec(self) -> None:
+        assert normalise_tool_name("execute_command") == "exec"
+
+    def test_write_file_maps_to_write(self) -> None:
+        assert normalise_tool_name("write_file") == "write"
+
+    def test_read_file_maps_to_read(self) -> None:
+        assert normalise_tool_name("read_file") == "read"
+
+    def test_edit_file_maps_to_edit(self) -> None:
+        assert normalise_tool_name("edit_file") == "edit"
+
+    def test_web_browse_maps_to_browser(self) -> None:
+        assert normalise_tool_name("web_browse") == "browser"
+
+    def test_send_message_maps_to_message(self) -> None:
+        assert normalise_tool_name("send_message") == "message"
+
+    def test_delegate_maps_to_sessions_spawn(self) -> None:
+        assert normalise_tool_name("delegate") == "sessions_spawn"
+
+    def test_code_execute_maps_to_code_execute(self) -> None:
+        assert normalise_tool_name("code_execute") == "code_execute"
+
+    def test_unknown_passes_through(self) -> None:
+        assert normalise_tool_name("custom_widget") == "custom_widget"
+
+
+class TestNormaliseToolCall:
+    def test_exec_with_command(self) -> None:
+        name, cmd = normalise_tool_call("terminal", {"command": "ls -la"})
+        assert name == "exec"
+        assert cmd == "ls -la"
+
+    def test_exec_with_cmd_alias(self) -> None:
+        name, cmd = normalise_tool_call("execute_command", {"cmd": "whoami"})
+        assert name == "exec"
+        assert cmd == "whoami"
+
+    def test_exec_no_command(self) -> None:
+        name, cmd = normalise_tool_call("terminal", {})
+        assert name == "exec"
+        assert cmd is None
+
+    def test_write_with_path(self) -> None:
+        name, cmd = normalise_tool_call("write_file", {"path": "/tmp/foo.txt"})
+        assert name == "write"
+        assert cmd == "Write: /tmp/foo.txt"
+
+    def test_write_with_file_path(self) -> None:
+        name, cmd = normalise_tool_call("create_file", {"file_path": "/tmp/bar.txt"})
+        assert name == "write"
+        assert cmd == "Write: /tmp/bar.txt"
+
+    def test_read_with_path(self) -> None:
+        name, cmd = normalise_tool_call("read_file", {"path": "/etc/hosts"})
+        assert name == "read"
+        assert cmd == "Read: /etc/hosts"
+
+    def test_edit_with_path(self) -> None:
+        name, cmd = normalise_tool_call("edit_file", {"path": "/src/main.py"})
+        assert name == "edit"
+        assert cmd == "Edit: /src/main.py"
+
+    def test_browser_with_url(self) -> None:
+        name, cmd = normalise_tool_call("web_browse", {
+            "action": "navigate",
+            "url": "https://example.com",
+        })
+        assert name == "browser"
+        assert cmd == "navigate: https://example.com"
+
+    def test_message_with_channel(self) -> None:
+        name, cmd = normalise_tool_call("telegram_send", {"channel": "#general"})
+        assert name == "message"
+        assert cmd == "Message to #general"
+
+    def test_message_without_channel(self) -> None:
+        name, cmd = normalise_tool_call("telegram_send", {})
+        assert name == "message"
+        assert cmd == "Message via telegram"
+
+    def test_sessions_spawn_with_agent(self) -> None:
+        name, cmd = normalise_tool_call("delegate", {"agent_id": "research-agent"})
+        assert name == "sessions_spawn"
+        assert cmd == "Spawn: research-agent"
+
+    def test_code_execute_with_code(self) -> None:
+        name, cmd = normalise_tool_call("python_execute", {"code": "print('hello')"})
+        assert name == "code_execute"
+        assert cmd == "Execute: print('hello')"
+
+    def test_code_execute_truncates_long_code(self) -> None:
+        long_code = "x = 1\n" * 100  # > 200 chars
+        name, cmd = normalise_tool_call("code_execute", {"code": long_code})
+        assert name == "code_execute"
+        assert cmd is not None
+        assert cmd.endswith("...")
+        assert len(cmd) <= 220  # "Execute: " + 200 + "..."
+
+    def test_web_search(self) -> None:
+        name, cmd = normalise_tool_call("web_search", {"query": "python dataclass"})
+        assert name == "web_search"
+        assert cmd == "Search: python dataclass"
+
+    def test_unknown_tool_uses_name_as_command(self) -> None:
+        name, cmd = normalise_tool_call("custom_tool", {"foo": "bar"})
+        assert name == "custom_tool"
+        assert cmd == "custom_tool"
+
+    def test_file_ops_with_no_path(self) -> None:
+        name, cmd = normalise_tool_call("write_file", {})
+        assert name == "write"
+        assert cmd == "Write: <unknown>"


### PR DESCRIPTION
Add a Python plugin for NousResearch's Hermes Agent that evaluates
every tool call against the AgentShield detection engine using Sigma
rules. Follows the same architecture as the existing OpenClaw plugin
with circuit breaker fault tolerance, event correlation, and
fire-and-forget audit logging.

Hooks registered:
- pre_tool_call: synchronous security evaluation (block/allow/log)
- post_tool_call: fire-and-forget audit report with correlation
- on_session_start / on_session_end: lifecycle tracking

Modules:
- client.py: stdlib HTTP client (zero external deps)
- circuit_breaker.py: three-state circuit breaker
- config.py: validated config with env var support
- normalise.py: maps 40+ Hermes tools to AgentShield canonical names
- event_builder.py: builds evaluation/audit/lifecycle payloads

Includes 65 passing tests covering all modules.

https://claude.ai/code/session_01DwdZzXqWUhcGktaiMwX74h