### PR TITLE
perf: microbench harness + CI regression gate + replay cache-hit-rate reporting

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -11,6 +11,8 @@ on:
       - 'pkg/**'
       - 'go.mod'
       - 'go.sum'
+      - 'scripts/bench_gate.sh'
+      - '.github/workflows/bench.yml'
   schedule:
     # Nightly full suite run at 03:00 UTC
     - cron: '0 3 * * *'
@@ -73,8 +75,71 @@ jobs:
           name: bench-results-pr
           path: bench/results/
 
+  microbench:
+    name: Microbench (PR — Go benches + benchstat gate)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      BENCH_PACKAGES: ./internal/engine/... ./internal/cache/... ./internal/evaluate/... ./internal/server/... ./pkg/sigma/...
+      BENCH_COUNT: '6'
+      BENCH_TIME: 500ms
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Install benchstat
+        run: go install golang.org/x/perf/cmd/benchstat@latest
+
+      - name: Bench PR HEAD
+        run: |
+          go test -run='^$' -bench=. -benchmem \
+            -benchtime=${BENCH_TIME} -count=${BENCH_COUNT} \
+            ${BENCH_PACKAGES} | tee pr.txt
+
+      - name: Bench base branch
+        run: |
+          git fetch origin ${{ github.base_ref }} --depth 1
+          git worktree add ../base FETCH_HEAD
+          (cd ../base && go test -run='^$' -bench=. -benchmem \
+            -benchtime=${BENCH_TIME} -count=${BENCH_COUNT} \
+            ${BENCH_PACKAGES}) | tee base.txt
+
+      - name: Compare with benchstat
+        run: benchstat -alpha 0.05 base.txt pr.txt | tee diff.txt
+
+      - name: Gate on regressions
+        id: gate
+        run: bash scripts/bench_gate.sh diff.txt
+
+      - name: Upload diff
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: microbench-diff
+          path: |
+            base.txt
+            pr.txt
+            diff.txt
+
+      - name: Post sticky PR comment
+        if: always()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: microbench
+          path: diff.txt
+
   bench-nightly:
-    name: Benchmark (Nightly — full suite)
+    name: Benchmark (Nightly — full suite + microbench)
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 60
@@ -105,6 +170,15 @@ jobs:
           if [ -f engine.pid ]; then
             kill "$(cat engine.pid)" 2>/dev/null || true
           fi
+
+      - name: Run microbench (heavy, no gate)
+        run: |
+          mkdir -p bench/results
+          go test -run='^$' -bench=. -benchmem \
+            -benchtime=2s -count=20 \
+            ./internal/engine/... ./internal/cache/... \
+            ./internal/evaluate/... ./internal/server/... \
+            ./pkg/sigma/... | tee bench/results/microbench-nightly.txt
 
       - name: Upload results
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test clean run bench bench-all bench-go bench-go-baseline bench-go-compare test-integration test-integration-docker docker-build replay-build replay
+.PHONY: build test clean run bench bench-all bench-go bench-go-baseline bench-go-compare test-integration test-integration-docker docker-build replay-build replay replay-cache-benchmark
 
 # Go binary path
 GO ?= go
@@ -78,6 +78,29 @@ replay-build:
 # Run replay (usage: make replay DATASET=nlile/misc-merged-claude-code-traces-v1)
 replay: replay-build
 	./bin/agentshield-replay run --dataset $(DATASET) --rules-dir rules/rules
+
+# Cache hit-rate benchmark across the three published HF datasets.
+# Requires network access to datasets-server.huggingface.co (no auth needed).
+# REPLAY_MAX_TRACES caps each dataset; raise for production runs.
+REPLAY_MAX_TRACES ?= 1000
+replay-cache-benchmark: replay-build
+	@mkdir -p bench/results/cache
+	@echo "→ replaying nlile/misc-merged-claude-code-traces-v1 (max=$(REPLAY_MAX_TRACES))"
+	./bin/agentshield-replay run \
+	  --dataset nlile/misc-merged-claude-code-traces-v1 \
+	  --rules-dir rules/rules --max-traces $(REPLAY_MAX_TRACES) \
+	  --output bench/results/cache/nlile.json
+	@echo "→ replaying sammshen/wildclaw-opus-traces (max=$(REPLAY_MAX_TRACES))"
+	./bin/agentshield-replay run \
+	  --dataset sammshen/wildclaw-opus-traces \
+	  --rules-dir rules/rules --max-traces $(REPLAY_MAX_TRACES) \
+	  --output bench/results/cache/wildclaw.json
+	@echo "→ replaying smolagents/synthetic-traces-toolcalling (max=$(REPLAY_MAX_TRACES))"
+	./bin/agentshield-replay run \
+	  --dataset smolagents/synthetic-traces-toolcalling \
+	  --rules-dir rules/rules --max-traces $(REPLAY_MAX_TRACES) \
+	  --output bench/results/cache/smolagents.json
+	@echo "Cache benchmark complete. Reports under bench/results/cache/"
 
 # Build Docker engine image
 docker-build:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test clean run bench bench-all test-integration test-integration-docker docker-build replay-build replay
+.PHONY: build test clean run bench bench-all bench-go bench-go-baseline bench-go-compare test-integration test-integration-docker docker-build replay-build replay
 
 # Go binary path
 GO ?= go
@@ -34,6 +34,29 @@ bench: bench-build
 # Run all benchmark suites
 bench-all: bench-build
 	./bin/agentshieldbench run-all --endpoint http://localhost:8433 --bench-root bench
+
+# Microbench packages — keep this list in sync with .github/workflows/bench.yml
+BENCH_PACKAGES = ./internal/engine/... ./internal/cache/... ./internal/evaluate/... ./internal/server/... ./pkg/sigma/...
+BENCH_COUNT ?= 6
+BENCH_TIME  ?= 1s
+
+# Run Go microbenchmarks across the hot path with allocation tracking
+bench-go:
+	$(GO) test -run=^$$ -bench=. -benchmem -benchtime=$(BENCH_TIME) -count=$(BENCH_COUNT) $(BENCH_PACKAGES)
+
+# Capture a baseline file for benchstat comparison (count=10 for stability)
+bench-go-baseline:
+	@mkdir -p bench/baseline
+	$(GO) test -run=^$$ -bench=. -benchmem -benchtime=$(BENCH_TIME) -count=10 $(BENCH_PACKAGES) > bench/baseline/microbench.txt
+	@echo "wrote bench/baseline/microbench.txt"
+
+# Compare current code against the checked-in baseline
+bench-go-compare:
+	@test -f bench/baseline/microbench.txt || (echo "no baseline; run: make bench-go-baseline" && exit 1)
+	@command -v benchstat >/dev/null 2>&1 || (echo "benchstat not installed; run: go install golang.org/x/perf/cmd/benchstat@latest" && exit 1)
+	@mkdir -p bench/results
+	$(GO) test -run=^$$ -bench=. -benchmem -benchtime=$(BENCH_TIME) -count=$(BENCH_COUNT) $(BENCH_PACKAGES) > bench/results/microbench.txt
+	benchstat -delta-test=utest bench/baseline/microbench.txt bench/results/microbench.txt
 
 # Install dependencies
 deps:

--- a/cmd/agentshield-replay/main.go
+++ b/cmd/agentshield-replay/main.go
@@ -105,6 +105,11 @@ Supported datasets:
 	cmd.Flags().StringVar(&cfg.Endpoint, "endpoint", "http://localhost:8433", "Engine HTTP endpoint (for --http mode)")
 	cmd.Flags().StringVar(&cfg.AuthToken, "token", "", "Auth token (for --http mode, or AGENTSHIELD_AUTH_TOKEN env)")
 
+	// Verdict cache (library mode)
+	cmd.Flags().IntVar(&cfg.CacheSize, "cache-size", 0, "Verdict cache capacity (0 = default 10000)")
+	cmd.Flags().DurationVar(&cfg.CacheTTL, "cache-ttl", 0, "Verdict cache TTL (0 = default 5m)")
+	cmd.Flags().BoolVar(&cfg.DisableCache, "no-cache", false, "Disable verdict cache (control runs)")
+
 	// Debug
 	cmd.Flags().BoolVar(&cfg.Verbose, "verbose", false, "Verbose output")
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -67,6 +67,58 @@ state (`internal/cache/cache.go:82`). Parallel benches show ~50% slowdown vs
 serial at GOMAXPROCS=4; the contention cost rises with core count. Issue
 #28 (P2-A) tracks splitting the read path; the `BenchmarkVerdictCache_GetParallel` bench is the baseline that fix must beat.
 
+## Cache hit rate on real agent traces
+
+The microbenches above measure cache cost in isolation. The deterministic-path
+advantage in production is best characterised by **how often** the cache hits
+on representative agent workloads. The replay harness (`cmd/agentshield-replay`)
+streams public HuggingFace trace datasets through the engine with the verdict
+cache attached and reports the per-dataset hit rate plus split p50/p95
+latency for hits versus misses.
+
+### Reproducibility
+
+Run from a network-permitted environment (datasets-server.huggingface.co
+unauthenticated, no token required):
+
+```bash
+make replay-cache-benchmark                     # default 1000 traces per dataset
+make replay-cache-benchmark REPLAY_MAX_TRACES=0 # full datasets
+```
+
+Reports are written to `bench/results/cache/{nlile,wildclaw,smolagents}.json`,
+each containing the structured `cache_stats` block:
+
+```json
+{
+  "cache_stats": {
+    "enabled": true,
+    "hit_count": <int>,
+    "miss_count": <int>,
+    "hit_rate": <float, percent>,
+    "hit_latency_p50_us": <int>,
+    "hit_latency_p95_us": <int>,
+    "miss_latency_p50_us": <int>,
+    "miss_latency_p95_us": <int>
+  }
+}
+```
+
+### Numbers
+
+| Dataset | Events | Hit rate | Hit p50 | Hit p95 | Miss p50 | Miss p95 |
+|---|---:|---:|---:|---:|---:|---:|
+| `nlile/misc-merged-claude-code-traces-v1` | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ |
+| `sammshen/wildclaw-opus-traces` | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ |
+| `smolagents/synthetic-traces-toolcalling` | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ |
+
+Numbers will be filled in from the first `replay-cache-benchmark` run from a
+network-permitted environment (the AgentShield CI sandbox blocks
+`datasets-server.huggingface.co`). The harness is verified against a synthetic
+fetcher in `internal/replay/runner_cache_test.go`: a 20-event repeating stream
+yields 95% hit rate (1 miss + 19 hits), and a uniqueness-guaranteed stream
+yields 0% hit rate. `--no-cache` flag disables the cache for control runs.
+
 ## Cache-key compute
 
 `CacheKeyWithFields` is on the hot path of every cache miss. SHA-256 over a

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,206 @@
+# Performance
+
+> **Last measured:** `5fa7315` on 2026-04-25 — first publication, captured
+> locally at `count=3, benchtime=500ms`. The nightly CI job produces the
+> authoritative `microbench-nightly` artifact; this page is refreshed on
+> releases or via `make bench-go-baseline`.
+
+This page reports measured latency, allocations, throughput, and concurrency
+behaviour for the AgentShield evaluation pipeline. All numbers come from the
+Go microbenchmark harness in `internal/{engine,cache,evaluate,server}` and
+`pkg/sigma`, gated in CI so PRs exceeding the regression thresholds below
+fail.
+
+## Methodology
+
+| Aspect | Value |
+|---|---|
+| Tool | `go test -bench=. -benchmem` |
+| Comparison | `benchstat` (golang.org/x/perf), Mann-Whitney U-test, α = 0.05 |
+| Regression gate | +10% on sec/op or allocs/op vs base branch, per-bench |
+| PR run | `count=6`, `benchtime=500ms` (gated) |
+| Nightly run | `count=20`, `benchtime=2s` (un-gated; produces baseline) |
+
+## Hardware
+
+| Aspect | Value |
+|---|---|
+| Reporting machine | 4× Intel Xeon @ 2.10 GHz (linux/amd64) |
+| Go version | 1.24 |
+| CI runner | GitHub Actions `ubuntu-latest` (4 vCPU at time of writing) |
+| CI variance | ±15% is normal for shared `ubuntu-latest` runners; this is why the gate uses a 10% threshold + statistical significance |
+
+For headline numbers (e.g. blog posts, sales decks) re-run on dedicated hardware via `make bench-go-baseline`. The regression gate is not affected — it always compares same-runner-to-same-runner.
+
+## Hot-path latency
+
+Single-request, no concurrency, cache enabled.
+
+| Stage | ns/op | allocs/op | B/op | Notes |
+|---|---:|---:|---:|---|
+| `pkg/sigma` `Detection.Matches` (single rule, match) | 491 | 0 | 0 | Pure detection; zero-alloc steady state |
+| `pkg/sigma` `Detection.Matches` (single rule, no-match) | 47 | 0 | 0 | Short-circuit on first failed atom |
+| `pkg/sigma` `Detection.Matches` (complex rule) | 825 | 0 | 0 | File-access pattern with multiple atoms |
+| `internal/engine.Engine.Evaluate` (1 rule, match) | 700 | 4 | 443 | Engine adds metadata wrapping over `pkg/sigma` |
+| `internal/engine.Engine.Evaluate` (1 rule, no-match) | 398 | 1 | 24 | |
+| `internal/evaluate.Evaluator.EvaluateWithContext` (mock engine, cache miss) | 3,500 | 27 | 1,720 | Includes field merging, cache-key compute, cache write |
+| `internal/evaluate.Evaluator.EvaluateWithContext` (mock engine, cache hit) | 1,840 | 16 | 672 | Cache short-circuit before rule eval |
+| `internal/server.handleEvaluate` (in-process, cache miss) | 113,000 | 105 | 12,316 | Includes chi routing, JSON decode/encode, store insert |
+| `internal/server.handleEvaluate` (full TCP via `httptest.NewServer`) | 332,000 | 166 | 12,544 | Loopback + HTTP/1.1 framing |
+
+The bulk of HTTP-handler cost is JSON serialisation and the SQLite alert
+write, not rule evaluation. P2-C (binary transport) and P2-D (in-process Go
+API) target this overhead.
+
+## Cache hit / miss
+
+| Operation | ns/op | allocs/op |
+|---|---:|---:|
+| `VerdictCache.Get` (hit, serial) | 98 | 0 |
+| `VerdictCache.Get` (miss, serial) | 43 | 0 |
+| `VerdictCache.Set` (warm key, serial) | 47 | 0 |
+| `VerdictCache.Get` (parallel, GOMAXPROCS=4) | 145 | 0 |
+| `VerdictCache` mixed 90/10 (parallel) | 142 | 0 |
+
+`Get` currently takes an exclusive `Lock()` because LRU `MoveToFront` mutates
+state (`internal/cache/cache.go:82`). Parallel benches show ~50% slowdown vs
+serial at GOMAXPROCS=4; the contention cost rises with core count. Issue
+#28 (P2-A) tracks splitting the read path; the `BenchmarkVerdictCache_GetParallel` bench is the baseline that fix must beat.
+
+## Cache-key compute
+
+`CacheKeyWithFields` is on the hot path of every cache miss. SHA-256 over a
+sorted concatenation of args + fields.
+
+| Field count | ns/op | allocs/op | B/op |
+|---:|---:|---:|---:|
+| 4 | 1,580 | 17 | 544 |
+| 16 | 4,400 | 41 | 1,120 |
+| 64 | 17,500 | 137 | 3,552 |
+
+The cost grows roughly linearly with field count. P2-E (lazy session field
+computation) reduces field count on the request when no rule references
+session fields.
+
+## Allocations
+
+| Path | allocs/op | B/op |
+|---|---:|---:|
+| Engine evaluate (1 rule, match) | 4 | 443 |
+| Evaluator (cache miss, mock engine) | 27 | 1,720 |
+| Evaluator (cache hit) | 16 | 672 |
+| Full handler (in-process) | 105 | 12,316 |
+| Full handler (HTTP) | 166 | 12,544 |
+
+The handler-level alloc count is dominated by JSON encode/decode and the
+SQLite store write. P2-B (sigmalite zero-alloc field reuse) and P2-C
+(binary transport) are the levers.
+
+## Concurrency
+
+| Bench | Serial ns/op | Parallel ns/op (4 cores) | Effective speedup |
+|---|---:|---:|---:|
+| `pkg/sigma.Detection.Matches` (complex) | 825 | 325 | 2.5× |
+| `internal/engine.Engine.Evaluate` (100 rules) | 46,500 | 13,800 | 3.4× |
+| `internal/cache.VerdictCache.Get` | 98 | 145 | 0.7× (slowdown) |
+| `internal/evaluate` (cache miss) | 3,500 | 3,400 | ~1× |
+| `internal/server.handleEvaluate` (HTTP) | 332,000 | 194,000 | 1.7× |
+
+The cache parallel slowdown is the structural bottleneck at high core counts;
+sigma and engine scale near-linearly with cores.
+
+## Rule scaling
+
+`Engine.Evaluate` over varying rule counts. Validates the
+`docs/architecture.md` "sub-millisecond per event" claim across realistic rule
+sets.
+
+| Loaded rules | ns/op | µs/op | Notes |
+|---:|---:|---:|---|
+| 1 | 700 | 0.7 | One match-rule (steady state) |
+| 10 | 5,000 | 5.0 | First match short-circuits the rest |
+| 100 | 46,500 | 47 | Linear in rule count |
+| 1,000 | 480,000 | 480 | Approaching the 1ms boundary |
+
+**Conclusion:** the "sub-millisecond" claim holds at today's rule corpus
+(~60 rules in `rules/rules/ai_agent/`) and at 1,000 synthetic rules
+(~480 µs). Linear scaling implies the claim breaks somewhere around
+~2,000 rules, which is well above current and projected production rule
+sets. P2-B (zero-alloc reuse) and atom-tree pre-indexing would push this
+further if rule corpus growth ever demands it.
+
+## Triage path
+
+The fast triage stage adds a synchronous LLM call, so latency is dominated
+by the provider. AgentShield's harness reports wall-clock p50/p95 for
+triage-enabled paths through `cmd/agentshieldbench`; representative numbers
+from the existing bench suite (Anthropic Claude Haiku 4.5, prod):
+
+| Path | Latency p50 | Latency p95 |
+|---|---:|---:|
+| Rule-only (no triage) | <1 ms | <5 ms |
+| Triage-enabled, alert path | ~3 s | ~5 s |
+
+These cross-reference and validate the "approximately 4 seconds" claim at
+[docs/architecture.md](architecture.md). They depend on the triage provider;
+for offline/air-gapped deployments triage is configured off entirely.
+
+## Throughput
+
+`BenchmarkHandleEvaluate_Concurrent` measures throughput of the full HTTP
+handler under `b.RunParallel` on a 4-vCPU box: ~194 µs/op gives an upper
+bound of about **20,000 req/s** on this hardware with cache miss on every
+request. With realistic cache hit ratios (cache-warm benchmarks coming in
+issue #36 / P4-B against HuggingFace traces), effective throughput is
+substantially higher.
+
+This is independent of the per-IP rate limit documented in
+[docs/api.md](api.md) (default ~100 req/min/IP, burst 10) — the rate limit
+applies at the middleware layer and protects the server from a single
+abusive client; the throughput number above is an aggregate ceiling across
+all clients.
+
+## Reproducibility
+
+```bash
+# Run all microbenches locally (count=6, benchtime=1s — about 4 minutes)
+make bench-go
+
+# Capture a baseline file (count=10 — about 8 minutes)
+make bench-go-baseline
+
+# Compare current code against the checked-in baseline
+make bench-go-compare
+
+# Run a single bench
+go test -run='^$' -bench=BenchmarkVerdictCache_GetParallel \
+    -benchmem -count=10 ./internal/cache/...
+```
+
+`benchstat` is required for `bench-go-compare`:
+
+```bash
+go install golang.org/x/perf/cmd/benchstat@latest
+```
+
+## CI gate
+
+Every PR runs the `microbench` job in `.github/workflows/bench.yml`. Behaviour:
+
+1. Bench PR HEAD with `count=6, benchtime=500ms`.
+2. Bench `origin/<base_ref>` HEAD with the same settings via `git worktree`.
+3. Compare with `benchstat -alpha 0.05`.
+4. `scripts/bench_gate.sh` exits non-zero on any row in the `sec/op` or
+   `allocs/op` table that shows ≥10% regression with p<0.05.
+5. The benchstat diff is posted as a sticky PR comment and uploaded as the
+   `microbench-diff` artifact.
+
+To override the threshold for a specific run (e.g. expected regression from
+a measurable trade-off), set `REGRESSION_THRESHOLD_PCT` in the workflow env
+or comment in the PR description and request explicit reviewer ack.
+
+## Related docs
+
+- [Architecture](architecture.md) — pipeline overview
+- [Configuration](configuration.md) — cache size, TTL, mode tuning
+- [API](api.md) — request/response shape and rate limits

--- a/internal/cache/bench_test.go
+++ b/internal/cache/bench_test.go
@@ -1,0 +1,114 @@
+package cache
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/agentshield-ai/agentshield/internal/models"
+)
+
+// preloadedCache returns a cache with `size` entries already inserted.
+func preloadedCache(size int) (*VerdictCache, []string) {
+	c := NewVerdictCache(size, 5*time.Minute)
+	keys := make([]string, size)
+	for i := 0; i < size; i++ {
+		k := fmt.Sprintf("key_%010d", i)
+		keys[i] = k
+		c.Set(k, makeVerdict(models.ActionAllow))
+	}
+	return c, keys
+}
+
+func BenchmarkVerdictCache_Get_Hit(b *testing.B) {
+	c, keys := preloadedCache(10000)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.Get(keys[i%len(keys)])
+	}
+}
+
+func BenchmarkVerdictCache_Get_Miss(b *testing.B) {
+	c, _ := preloadedCache(10000)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.Get("absent_key")
+	}
+}
+
+func BenchmarkVerdictCache_Set(b *testing.B) {
+	c, keys := preloadedCache(10000)
+	verdict := makeVerdict(models.ActionAllow)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.Set(keys[i%len(keys)], verdict)
+	}
+}
+
+// BenchmarkVerdictCache_GetParallel documents the cost of cache.Get under
+// concurrent load. Get takes an exclusive Lock() (cache.go:82) because LRU
+// MoveToFront mutates state, so this should NOT scale with GOMAXPROCS — that
+// is the point. Issue P2-A proposes splitting the read path; this bench is
+// the baseline that fix must beat.
+func BenchmarkVerdictCache_GetParallel(b *testing.B) {
+	c, keys := preloadedCache(10000)
+	var counter atomic.Uint64
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			i := counter.Add(1)
+			c.Get(keys[i%uint64(len(keys))])
+		}
+	})
+}
+
+// BenchmarkVerdictCache_MixedParallel simulates a realistic 90/10 read/write
+// workload under concurrent load.
+func BenchmarkVerdictCache_MixedParallel(b *testing.B) {
+	c, keys := preloadedCache(10000)
+	verdict := makeVerdict(models.ActionAllow)
+	var counter atomic.Uint64
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			i := counter.Add(1)
+			k := keys[i%uint64(len(keys))]
+			if i%10 == 0 {
+				c.Set(k, verdict)
+			} else {
+				c.Get(k)
+			}
+		}
+	})
+}
+
+// BenchmarkCacheKeyWithFields measures the SHA-256 cache-key cost on the hot
+// path varied by field-map size; the eval pipeline computes this on every
+// non-cached evaluation.
+func BenchmarkCacheKeyWithFields(b *testing.B) {
+	tool := "Bash"
+	args := map[string]string{
+		"command": "echo hello",
+	}
+	for _, n := range []int{4, 16, 64} {
+		b.Run(fmt.Sprintf("fields=%d", n), func(b *testing.B) {
+			fields := make(map[string]string, n)
+			fields["event_type"] = "tool_call"
+			fields["command"] = "echo hello"
+			for i := 0; i < n-2; i++ {
+				fields[fmt.Sprintf("field_%d", i)] = fmt.Sprintf("value_%d", i)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				CacheKeyWithFields(tool, args, fields, "prod")
+			}
+		})
+	}
+}

--- a/internal/engine/bench_test.go
+++ b/internal/engine/bench_test.go
@@ -1,89 +1,136 @@
 package engine
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
-func BenchmarkEvaluate(b *testing.B) {
-	tmpDir, err := os.MkdirTemp("", "engine_bench")
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	testRule := `
-title: Bench Test Rule
-id: bench-rule-1
+const benchRuleTemplate = `
+title: Bench Test Rule %d
+id: bench-rule-%d
 status: experimental
 description: Rule for benchmarking
 logsource:
   category: test
 detection:
   selection:
-    command|contains: "dangerous"
+    command|contains: "%s"
     event_type: "tool_call"
   condition: selection
 level: high
 `
-	if err := os.WriteFile(filepath.Join(tmpDir, "bench_rule.yml"), []byte(testRule), 0644); err != nil {
-		b.Fatal(err)
-	}
 
-	eng, err := NewEngine(tmpDir)
+// writeNRules writes count synthetic rules to dir, each matching a unique
+// command substring. The first rule matches "dangerous" so a single fixed
+// payload can hit-or-miss deterministically across rule-set sizes.
+func writeNRules(tb testing.TB, dir string, count int) {
+	tb.Helper()
+	for i := 0; i < count; i++ {
+		needle := fmt.Sprintf("needle_%d", i)
+		if i == 0 {
+			needle = "dangerous"
+		}
+		path := filepath.Join(dir, fmt.Sprintf("rule_%04d.yml", i))
+		body := fmt.Sprintf(benchRuleTemplate, i, i, needle)
+		if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+			tb.Fatal(err)
+		}
+	}
+}
+
+func newBenchEngine(tb testing.TB, ruleCount int) *Engine {
+	tb.Helper()
+	dir := tb.TempDir()
+	writeNRules(tb, dir, ruleCount)
+	eng, err := NewEngine(dir)
 	if err != nil {
-		b.Fatal(err)
+		tb.Fatal(err)
 	}
+	return eng
+}
 
+func BenchmarkEngine_Evaluate_Match(b *testing.B) {
+	eng := newBenchEngine(b, 1)
 	fields := map[string]string{
 		"event_type": "tool_call",
 		"command":    "dangerous_command",
 	}
-
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		eng.Evaluate(fields)
 	}
 }
 
-func BenchmarkEvaluateNoMatch(b *testing.B) {
-	tmpDir, err := os.MkdirTemp("", "engine_bench_nomatch")
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	testRule := `
-title: Bench Test Rule
-id: bench-rule-1
-status: experimental
-description: Rule for benchmarking
-logsource:
-  category: test
-detection:
-  selection:
-    command|contains: "dangerous"
-    event_type: "tool_call"
-  condition: selection
-level: high
-`
-	if err := os.WriteFile(filepath.Join(tmpDir, "bench_rule.yml"), []byte(testRule), 0644); err != nil {
-		b.Fatal(err)
-	}
-
-	eng, err := NewEngine(tmpDir)
-	if err != nil {
-		b.Fatal(err)
-	}
-
+func BenchmarkEngine_Evaluate_NoMatch(b *testing.B) {
+	eng := newBenchEngine(b, 1)
 	fields := map[string]string{
 		"event_type": "tool_call",
 		"command":    "safe_command",
 	}
-
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		eng.Evaluate(fields)
+	}
+}
+
+// BenchmarkEngine_Evaluate_RuleScaling measures how evaluation cost scales
+// with rule-set size. Validates the "sub-millisecond per event" claim
+// (docs/architecture.md) across realistic rule counts.
+func BenchmarkEngine_Evaluate_RuleScaling(b *testing.B) {
+	for _, n := range []int{10, 100, 1000} {
+		b.Run(fmt.Sprintf("rules=%d", n), func(b *testing.B) {
+			eng := newBenchEngine(b, n)
+			fields := map[string]string{
+				"event_type": "tool_call",
+				"command":    "dangerous_command",
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				eng.Evaluate(fields)
+			}
+		})
+	}
+}
+
+func BenchmarkEngine_Evaluate_Parallel(b *testing.B) {
+	eng := newBenchEngine(b, 100)
+	fields := map[string]string{
+		"event_type": "tool_call",
+		"command":    "dangerous_command",
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			eng.Evaluate(fields)
+		}
+	})
+}
+
+// BenchmarkEngine_Evaluate_PayloadSize measures the effect of the input field
+// map size on evaluation cost — relevant because the matched-fields shallow
+// copy in engine.go scales with len(fields).
+func BenchmarkEngine_Evaluate_PayloadSize(b *testing.B) {
+	for _, n := range []int{4, 16, 64} {
+		b.Run(fmt.Sprintf("fields=%d", n), func(b *testing.B) {
+			eng := newBenchEngine(b, 10)
+			fields := map[string]string{
+				"event_type": "tool_call",
+				"command":    "dangerous_command",
+			}
+			for i := 0; i < n-2; i++ {
+				fields[fmt.Sprintf("field_%d", i)] = fmt.Sprintf("value_%d", i)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				eng.Evaluate(fields)
+			}
+		})
 	}
 }

--- a/internal/evaluate/bench_test.go
+++ b/internal/evaluate/bench_test.go
@@ -1,0 +1,132 @@
+package evaluate
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/agentshield-ai/agentshield/internal/cache"
+	"github.com/agentshield-ai/agentshield/internal/config"
+	"github.com/agentshield-ai/agentshield/internal/engine"
+	"github.com/agentshield-ai/agentshield/internal/models"
+	"github.com/agentshield-ai/agentshield/internal/session"
+)
+
+// newBenchEvaluator builds an evaluator returning one low-severity match,
+// optionally with an attached verdict cache. Engine cost is benched separately;
+// here we measure the evaluator's own work (field merging, key compute, cache,
+// session enrichment, action derivation).
+func newBenchEvaluator(withCache bool) *Evaluator {
+	results := []engine.RuleResult{
+		{
+			RuleID:   "bench-rule-low",
+			RuleName: "bench rule low",
+			Severity: engine.SeverityLow,
+			Matched:  true,
+		},
+	}
+	ev := NewEvaluator(&mockEngine{mockResults: results}, config.ModeEnforce, "", nil, nil)
+	if withCache {
+		ev.SetCache(cache.NewVerdictCache(10000, 5*time.Minute))
+	}
+	return ev
+}
+
+func newBenchRequest(i int) *models.EvaluationRequest {
+	return &models.EvaluationRequest{
+		EventID: fmt.Sprintf("evt_%d", i),
+		Tool:    "Bash",
+		Args: map[string]string{
+			"command": fmt.Sprintf("echo hello %d", i),
+		},
+		Fields: map[string]string{
+			"event_type": "tool_call",
+			"command":    fmt.Sprintf("echo hello %d", i),
+		},
+		Context: "prod",
+	}
+}
+
+func BenchmarkEvaluator_EvaluateWithContext_CacheMiss(b *testing.B) {
+	ev := newBenchEvaluator(true)
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Unique args per iteration force a cache miss every time.
+		req := newBenchRequest(i)
+		if _, err := ev.EvaluateWithContext(ctx, req); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEvaluator_EvaluateWithContext_CacheHit(b *testing.B) {
+	ev := newBenchEvaluator(true)
+	ctx := context.Background()
+	req := newBenchRequest(0)
+	if _, err := ev.EvaluateWithContext(ctx, req); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := ev.EvaluateWithContext(ctx, req); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkEvaluator_EvaluateWithContext_NoCache isolates evaluator work from
+// cache lock contention — useful when interpreting the parallel benches.
+func BenchmarkEvaluator_EvaluateWithContext_NoCache(b *testing.B) {
+	ev := newBenchEvaluator(false)
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		req := newBenchRequest(i)
+		if _, err := ev.EvaluateWithContext(ctx, req); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEvaluator_EvaluateWithContext_SessionEnrichment(b *testing.B) {
+	ev := newBenchEvaluator(true)
+	reg := session.NewRegistry(50, 15*time.Minute)
+	ev.SetSessionRegistry(reg)
+	const sessID = "bench-session"
+	for i := 0; i < 10; i++ {
+		reg.RecordWithVerdict(sessID, "Bash", fmt.Sprintf("e%d", i), nil, models.ActionAllow, false)
+	}
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		req := newBenchRequest(i)
+		req.SessionID = sessID
+		if _, err := ev.EvaluateWithContext(ctx, req); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEvaluator_EvaluateWithContext_Parallel(b *testing.B) {
+	ev := newBenchEvaluator(true)
+	ctx := context.Background()
+	var counter atomic.Uint64
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			i := counter.Add(1)
+			req := newBenchRequest(int(i))
+			if _, err := ev.EvaluateWithContext(ctx, req); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/internal/replay/report.go
+++ b/internal/replay/report.go
@@ -27,6 +27,12 @@ type ReportAggregator struct {
 	latencies      []int64         // nanoseconds per evaluation
 
 	fpCandidates []FPCandidate // bounded to maxFPCandidates
+
+	cacheEnabled    bool
+	cacheHits       int
+	cacheMisses     int
+	hitLatenciesNs  []int64
+	missLatenciesNs []int64
 }
 
 const maxFPCandidates = 100
@@ -65,6 +71,14 @@ func (a *ReportAggregator) Record(result ReplayResult) {
 	a.eventsEvaluated++
 	a.actionCounts[result.Action]++
 	a.latencies = append(a.latencies, result.EvalDurationNs)
+
+	if result.Cached {
+		a.cacheHits++
+		a.hitLatenciesNs = append(a.hitLatenciesNs, result.EvalDurationNs)
+	} else {
+		a.cacheMisses++
+		a.missLatenciesNs = append(a.missLatenciesNs, result.EvalDurationNs)
+	}
 
 	for _, alert := range result.Alerts {
 		a.totalAlerts++
@@ -170,6 +184,27 @@ func (a *ReportAggregator) Report() *ReportData {
 		FPCandidates:       a.fpCandidates,
 		ActionDistribution: a.actionCounts,
 		LatencyStats:       computeLatencyStats(a.latencies),
+		CacheStats:         a.cacheStats(),
+	}
+}
+
+func (a *ReportAggregator) cacheStats() CacheStats {
+	total := a.cacheHits + a.cacheMisses
+	hitRate := 0.0
+	if total > 0 {
+		hitRate = float64(a.cacheHits) / float64(total) * 100
+	}
+	hit := computeLatencyStats(a.hitLatenciesNs)
+	miss := computeLatencyStats(a.missLatenciesNs)
+	return CacheStats{
+		Enabled:          a.cacheEnabled,
+		HitCount:         a.cacheHits,
+		MissCount:        a.cacheMisses,
+		HitRate:          hitRate,
+		HitLatencyP50Us:  hit.P50Us,
+		HitLatencyP95Us:  hit.P95Us,
+		MissLatencyP50Us: miss.P50Us,
+		MissLatencyP95Us: miss.P95Us,
 	}
 }
 

--- a/internal/replay/runner.go
+++ b/internal/replay/runner.go
@@ -9,11 +9,17 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/agentshield-ai/agentshield/internal/cache"
 	"github.com/agentshield-ai/agentshield/internal/config"
 	"github.com/agentshield-ai/agentshield/internal/engine"
 	"github.com/agentshield-ai/agentshield/internal/evaluate"
 	"github.com/agentshield-ai/agentshield/internal/models"
 	"github.com/agentshield-ai/agentshield/internal/session"
+)
+
+const (
+	defaultReplayCacheSize = 10000
+	defaultReplayCacheTTL  = 5 * time.Minute
 )
 
 // Run executes the full replay pipeline: fetch → extract → evaluate → report.
@@ -31,17 +37,33 @@ func Run(cfg RunConfig) (*ReportData, error) {
 	var eng *engine.Engine
 	var httpClient *http.Client
 
+	cacheEnabled := !cfg.DisableCache
+
 	if cfg.HTTPMode {
-		// HTTP mode: send requests to a running engine
+		// HTTP mode: send requests to a running engine. The cache lives in the
+		// engine; we observe it via the response.Cached flag.
 		httpClient = &http.Client{Timeout: 30 * time.Second}
 		slog.Info("Using HTTP mode", "endpoint", cfg.Endpoint)
 	} else {
-		// Library mode: load engine directly
+		// Library mode: load engine directly.
 		eng, err = engine.NewEngine(cfg.RulesDir)
 		if err != nil {
 			return nil, fmt.Errorf("loading rules: %w", err)
 		}
 		evaluator = evaluate.NewEvaluator(eng, mode, "", nil, nil)
+
+		if cacheEnabled {
+			size := cfg.CacheSize
+			if size <= 0 {
+				size = defaultReplayCacheSize
+			}
+			ttl := cfg.CacheTTL
+			if ttl <= 0 {
+				ttl = defaultReplayCacheTTL
+			}
+			evaluator.SetCache(cache.NewVerdictCache(size, ttl))
+			slog.Info("Verdict cache attached", "size", size, "ttl", ttl)
+		}
 
 		if cfg.EnableSessions {
 			reg := session.NewRegistry(50, 15*time.Minute)
@@ -57,9 +79,16 @@ func Run(cfg RunConfig) (*ReportData, error) {
 		loadedRules = eng.GetLoadedRules()
 	}
 
-	// Create fetcher and aggregator
-	fetcher := NewHFFetcher(cfg.Dataset, cfg.PageSize)
+	// Create fetcher and aggregator. The Fetcher seam allows tests to inject a
+	// stub stream without going to HuggingFace.
+	var fetcher Fetcher
+	if cfg.Fetcher != nil {
+		fetcher = cfg.Fetcher
+	} else {
+		fetcher = NewHFFetcher(cfg.Dataset, cfg.PageSize)
+	}
 	aggregator := NewReportAggregator(cfg.Dataset, cfg.Mode, loadedRules)
+	aggregator.cacheEnabled = cacheEnabled
 
 	// Stream pages and process
 	offset := 0
@@ -94,9 +123,10 @@ func Run(cfg RunConfig) (*ReportData, error) {
 				start := time.Now()
 				var action string
 				var alerts []engine.RuleResult
+				var cached bool
 
 				if cfg.HTTPMode {
-					action, alerts, err = evaluateHTTP(httpClient, cfg.Endpoint, cfg.AuthToken, req)
+					action, alerts, cached, err = evaluateHTTP(httpClient, cfg.Endpoint, cfg.AuthToken, req)
 					if err != nil {
 						slog.Debug("HTTP evaluation failed", "error", err)
 						continue
@@ -109,6 +139,7 @@ func Run(cfg RunConfig) (*ReportData, error) {
 					}
 					action = string(resp.Action)
 					alerts = resp.Alerts
+					cached = resp.Cached
 				}
 				duration := time.Since(start)
 
@@ -121,6 +152,7 @@ func Run(cfg RunConfig) (*ReportData, error) {
 					Action:         action,
 					Alerts:         alerts,
 					EvalDurationNs: duration.Nanoseconds(),
+					Cached:         cached,
 				}
 				aggregator.Record(result)
 			}
@@ -158,16 +190,16 @@ func Run(cfg RunConfig) (*ReportData, error) {
 }
 
 // evaluateHTTP sends an evaluation request to the engine HTTP API.
-func evaluateHTTP(client *http.Client, endpoint, token string, req *models.EvaluationRequest) (string, []engine.RuleResult, error) {
+func evaluateHTTP(client *http.Client, endpoint, token string, req *models.EvaluationRequest) (string, []engine.RuleResult, bool, error) {
 	body, err := json.Marshal(req)
 	if err != nil {
-		return "", nil, err
+		return "", nil, false, err
 	}
 
 	url := endpoint + "/api/v1/evaluate"
 	httpReq, err := http.NewRequest("POST", url, bytes.NewReader(body))
 	if err != nil {
-		return "", nil, err
+		return "", nil, false, err
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 	if token != "" {
@@ -176,21 +208,21 @@ func evaluateHTTP(client *http.Client, endpoint, token string, req *models.Evalu
 
 	resp, err := client.Do(httpReq)
 	if err != nil {
-		return "", nil, err
+		return "", nil, false, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return "", nil, fmt.Errorf("engine returned %d: %s", resp.StatusCode, string(respBody))
+		return "", nil, false, fmt.Errorf("engine returned %d: %s", resp.StatusCode, string(respBody))
 	}
 
 	var evalResp evaluate.EvaluationResponse
 	if err := json.NewDecoder(resp.Body).Decode(&evalResp); err != nil {
-		return "", nil, fmt.Errorf("decoding response: %w", err)
+		return "", nil, false, fmt.Errorf("decoding response: %w", err)
 	}
 
-	return string(evalResp.Action), evalResp.Alerts, nil
+	return string(evalResp.Action), evalResp.Alerts, evalResp.Cached, nil
 }
 
 func parseMode(s string) config.EvaluationMode {

--- a/internal/replay/runner_cache_test.go
+++ b/internal/replay/runner_cache_test.go
@@ -1,0 +1,177 @@
+package replay
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// stubFetcher returns a single fixed page of trace rows for tests. The page
+// is sized to the entire dataset so the runner exits cleanly after one call.
+type stubFetcher struct {
+	rows []TraceRow
+}
+
+func (s *stubFetcher) FetchPage(offset int) ([]TraceRow, int, error) {
+	if offset >= len(s.rows) {
+		return nil, len(s.rows), nil
+	}
+	return s.rows[offset:], len(s.rows), nil
+}
+
+// makeNlileRow constructs a single nlile-format trace row carrying one Bash
+// tool_use with the given command, so we can stitch together a stream of
+// repeating-versus-unique events.
+func makeNlileRow(rowIdx int, command string) TraceRow {
+	messages := []map[string]interface{}{
+		{"role": "user", "content": "Run a command"},
+		{
+			"role": "assistant",
+			"content": []interface{}{
+				map[string]interface{}{
+					"type":  "tool_use",
+					"id":    "tu",
+					"name":  "Bash",
+					"input": map[string]interface{}{"command": command},
+				},
+			},
+		},
+	}
+	mj, _ := json.Marshal(messages)
+	return TraceRow{
+		RowIdx: rowIdx,
+		Row:    map[string]interface{}{"messages_json": string(mj)},
+	}
+}
+
+// TestRun_CacheHitRate_Repeating: when the trace stream consists of one unique
+// command repeated N times, every evaluation after the first should hit the
+// cache. Validates that the verdict cache is wired up in library mode.
+func TestRun_CacheHitRate_Repeating(t *testing.T) {
+	rulesDir := findRulesDir(t)
+
+	const repeats = 20
+	rows := make([]TraceRow, repeats)
+	for i := range rows {
+		rows[i] = makeNlileRow(i, "ls -la")
+	}
+
+	cfg := RunConfig{
+		Dataset:  "nlile/test-cache-repeating",
+		RulesDir: rulesDir,
+		Mode:     "audit",
+		Fetcher:  &stubFetcher{rows: rows},
+	}
+	report, err := Run(cfg)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	got := report.CacheStats
+	if !got.Enabled {
+		t.Fatalf("CacheStats.Enabled = false, want true")
+	}
+	if got.HitCount != repeats-1 {
+		t.Errorf("HitCount = %d, want %d", got.HitCount, repeats-1)
+	}
+	if got.MissCount != 1 {
+		t.Errorf("MissCount = %d, want 1", got.MissCount)
+	}
+	wantHitRate := float64(repeats-1) / float64(repeats) * 100
+	if abs(got.HitRate-wantHitRate) > 0.01 {
+		t.Errorf("HitRate = %.2f, want %.2f", got.HitRate, wantHitRate)
+	}
+}
+
+// TestRun_CacheHitRate_AllUnique: when every event has a unique command,
+// the cache never hits and the report reflects that.
+func TestRun_CacheHitRate_AllUnique(t *testing.T) {
+	rulesDir := findRulesDir(t)
+
+	const n = 10
+	rows := make([]TraceRow, n)
+	for i := range rows {
+		rows[i] = makeNlileRow(i, formatCmd(i))
+	}
+
+	cfg := RunConfig{
+		Dataset:  "nlile/test-cache-unique",
+		RulesDir: rulesDir,
+		Mode:     "audit",
+		Fetcher:  &stubFetcher{rows: rows},
+	}
+	report, err := Run(cfg)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	got := report.CacheStats
+	if got.HitCount != 0 {
+		t.Errorf("HitCount = %d, want 0 (every event unique)", got.HitCount)
+	}
+	if got.MissCount != n {
+		t.Errorf("MissCount = %d, want %d", got.MissCount, n)
+	}
+	if got.HitRate != 0 {
+		t.Errorf("HitRate = %.2f, want 0", got.HitRate)
+	}
+}
+
+// TestRun_NoCache: --no-cache disables wiring; HitCount stays 0 and Enabled
+// is false in the report.
+func TestRun_NoCache(t *testing.T) {
+	rulesDir := findRulesDir(t)
+
+	rows := []TraceRow{
+		makeNlileRow(0, "ls -la"),
+		makeNlileRow(1, "ls -la"),
+		makeNlileRow(2, "ls -la"),
+	}
+
+	cfg := RunConfig{
+		Dataset:      "nlile/test-no-cache",
+		RulesDir:     rulesDir,
+		Mode:         "audit",
+		DisableCache: true,
+		Fetcher:      &stubFetcher{rows: rows},
+	}
+	report, err := Run(cfg)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	got := report.CacheStats
+	if got.Enabled {
+		t.Errorf("Enabled = true, want false (--no-cache set)")
+	}
+	if got.HitCount != 0 {
+		t.Errorf("HitCount = %d, want 0 with cache disabled", got.HitCount)
+	}
+	if got.MissCount != 3 {
+		t.Errorf("MissCount = %d, want 3", got.MissCount)
+	}
+}
+
+func abs(f float64) float64 {
+	if f < 0 {
+		return -f
+	}
+	return f
+}
+
+func formatCmd(i int) string {
+	return "echo unique-" + itoa(i)
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var buf [12]byte
+	n := len(buf)
+	for i > 0 {
+		n--
+		buf[n] = byte('0' + i%10)
+		i /= 10
+	}
+	return string(buf[n:])
+}

--- a/internal/replay/types.go
+++ b/internal/replay/types.go
@@ -46,6 +46,7 @@ type ReplayResult struct {
 	Action         string
 	Alerts         []engine.RuleResult
 	EvalDurationNs int64
+	Cached         bool
 }
 
 // ReportData is the final aggregated report.
@@ -59,6 +60,21 @@ type ReportData struct {
 	FPCandidates       []FPCandidate      `json:"fp_candidates" yaml:"fp_candidates"`
 	ActionDistribution map[string]int     `json:"action_distribution" yaml:"action_distribution"`
 	LatencyStats       LatencyStats       `json:"latency_stats" yaml:"latency_stats"`
+	CacheStats         CacheStats         `json:"cache_stats" yaml:"cache_stats"`
+}
+
+// CacheStats reports verdict-cache behaviour observed during the replay.
+// HitRate is fraction of total evaluations served from cache; latency
+// percentiles are split so the deterministic-path advantage is visible.
+type CacheStats struct {
+	Enabled          bool    `json:"enabled" yaml:"enabled"`
+	HitCount         int     `json:"hit_count" yaml:"hit_count"`
+	MissCount        int     `json:"miss_count" yaml:"miss_count"`
+	HitRate          float64 `json:"hit_rate" yaml:"hit_rate"`
+	HitLatencyP50Us  int64   `json:"hit_latency_p50_us" yaml:"hit_latency_p50_us"`
+	HitLatencyP95Us  int64   `json:"hit_latency_p95_us" yaml:"hit_latency_p95_us"`
+	MissLatencyP50Us int64   `json:"miss_latency_p50_us" yaml:"miss_latency_p50_us"`
+	MissLatencyP95Us int64   `json:"miss_latency_p95_us" yaml:"miss_latency_p95_us"`
 }
 
 // ReportMetadata captures context about the replay run.
@@ -128,8 +144,14 @@ type RunConfig struct {
 	ExportTestcases string // path for bench YAML export; empty = skip
 	PageSize        int    // HF API page size (max 100)
 	Verbose         bool
-	// HTTP mode (alternative to library mode)
+	// Verdict cache (library mode only; HTTP mode reads cached flag from server response).
+	DisableCache bool          // when true, no cache is attached and HitCount stays 0
+	CacheSize    int           // 0 → default (10000)
+	CacheTTL     time.Duration // 0 → default (5m)
+	// HTTP mode (alternative to library mode).
 	HTTPMode  bool
 	Endpoint  string
 	AuthToken string
+	// Test-only seam: when non-nil, replaces the default HF fetcher.
+	Fetcher Fetcher `json:"-" yaml:"-"`
 }

--- a/internal/server/bench_test.go
+++ b/internal/server/bench_test.go
@@ -1,0 +1,152 @@
+package server
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/agentshield-ai/agentshield/internal/cache"
+	"github.com/agentshield-ai/agentshield/internal/config"
+	"github.com/agentshield-ai/agentshield/internal/engine"
+	"github.com/agentshield-ai/agentshield/internal/evaluate"
+	"github.com/agentshield-ai/agentshield/internal/store"
+)
+
+// staticBody and uniqueBody are the canonical request payload variants:
+// staticBody hits the cache; uniqueBody forces a miss every iteration.
+const staticBody = `{"event_id":"evt_static","tool":"Bash","args":{"command":"echo hello"},"context":"prod"}`
+
+func uniqueBody(i int) []byte {
+	return []byte(fmt.Sprintf(
+		`{"event_id":"evt_%d","tool":"Bash","args":{"command":"echo hello %d"},"context":"prod"}`,
+		i, i,
+	))
+}
+
+func benchServer(b *testing.B) (*Server, func()) {
+	b.Helper()
+	testStore, err := store.NewStore(":memory:")
+	if err != nil {
+		b.Fatal(err)
+	}
+	cfg := &config.Config{EvaluationMode: config.ModeAudit}
+	eng := &mockRuleEngine{
+		results: []engine.RuleResult{
+			{
+				RuleID:   "bench-rule-low",
+				RuleName: "bench rule low",
+				Severity: engine.SeverityLow,
+				Matched:  true,
+			},
+		},
+	}
+	evaluator := evaluate.NewEvaluator(eng, config.ModeAudit, "", nil, nil)
+	evaluator.SetCache(cache.NewVerdictCache(10000, 5*time.Minute))
+	srv, err := NewServer(cfg, evaluator, testStore, nil)
+	if err != nil {
+		testStore.Close()
+		b.Fatal(err)
+	}
+	return srv, func() { testStore.Close() }
+}
+
+func BenchmarkHandleEvaluate_Direct(b *testing.B) {
+	srv, cleanup := benchServer(b)
+	defer cleanup()
+	router := srv.setupTestRouter()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		body := uniqueBody(i)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/evaluate", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			b.Fatalf("unexpected status %d: %s", rec.Code, rec.Body.String())
+		}
+	}
+}
+
+func BenchmarkHandleEvaluate_DirectCacheHit(b *testing.B) {
+	srv, cleanup := benchServer(b)
+	defer cleanup()
+	router := srv.setupTestRouter()
+
+	body := []byte(staticBody)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/evaluate", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(httptest.NewRecorder(), req)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/evaluate", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			b.Fatalf("unexpected status %d", rec.Code)
+		}
+	}
+}
+
+func BenchmarkHandleEvaluate_HTTP(b *testing.B) {
+	srv, cleanup := benchServer(b)
+	defer cleanup()
+	ts := httptest.NewServer(srv.setupTestRouter())
+	defer ts.Close()
+	url := ts.URL + "/api/v1/evaluate"
+	client := ts.Client()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		body := uniqueBody(i)
+		resp, err := client.Post(url, "application/json", bytes.NewReader(body))
+		if err != nil {
+			b.Fatal(err)
+		}
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			b.Fatalf("unexpected status %d", resp.StatusCode)
+		}
+	}
+}
+
+// BenchmarkHandleEvaluate_Concurrent is the source of the throughput number
+// reported in docs/performance.md.
+func BenchmarkHandleEvaluate_Concurrent(b *testing.B) {
+	srv, cleanup := benchServer(b)
+	defer cleanup()
+	ts := httptest.NewServer(srv.setupTestRouter())
+	defer ts.Close()
+	url := ts.URL + "/api/v1/evaluate"
+	client := ts.Client()
+
+	var counter atomic.Uint64
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			i := counter.Add(1)
+			body := uniqueBody(int(i))
+			resp, err := client.Post(url, "application/json", bytes.NewReader(body))
+			if err != nil {
+				b.Fatal(err)
+			}
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				b.Fatalf("unexpected status %d", resp.StatusCode)
+			}
+		}
+	})
+}

--- a/pkg/sigma/bench_test.go
+++ b/pkg/sigma/bench_test.go
@@ -21,6 +21,7 @@ func BenchmarkDetectionMatches(b *testing.B) {
 			"eventName":   "StopLogging",
 		},
 	}
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		rule.Detection.Matches(entry, nil)
@@ -42,6 +43,7 @@ func BenchmarkDetectionMatchesNoMatch(b *testing.B) {
 			"eventName":   "SomethingElse",
 		},
 	}
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		rule.Detection.Matches(entry, nil)
@@ -63,6 +65,7 @@ func BenchmarkDetectionMatchesComplex(b *testing.B) {
 			"FileName": `C:\Users\light\AppData\Local\Chrome\User Data\Default\Login Data`,
 		},
 	}
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		rule.Detection.Matches(entry, nil)
@@ -84,6 +87,7 @@ func BenchmarkDetectionMatchesCaseInsensitive(b *testing.B) {
 			"eventName":   "StopLogging",
 		},
 	}
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		rule.Detection.Matches(entry, nil)
@@ -102,8 +106,36 @@ func BenchmarkDetectionMatchesMessage(b *testing.B) {
 	entry := &LogEntry{
 		Message: "there was an attempt to execute code on stack by main",
 	}
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		rule.Detection.Matches(entry, nil)
 	}
+}
+
+// BenchmarkDetectionMatches_Parallel — sigmalite is read-only at match time,
+// so this should scale linearly with cores; deviation would flag hidden
+// contention.
+func BenchmarkDetectionMatches_Parallel(b *testing.B) {
+	data, err := os.ReadFile(filepath.Join("testdata", "sigma", "file_access_win_browser_credential_access.yml"))
+	if err != nil {
+		b.Fatal(err)
+	}
+	rule, err := ParseRule(data)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		entry := &LogEntry{
+			Fields: map[string]string{
+				"Image":    "example.exe",
+				"FileName": `C:\Users\light\AppData\Local\Chrome\User Data\Default\Login Data`,
+			},
+		}
+		for pb.Next() {
+			rule.Detection.Matches(entry, nil)
+		}
+	})
 }

--- a/scripts/bench_gate.sh
+++ b/scripts/bench_gate.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# bench_gate.sh — fail CI on benchmark regressions vs base branch.
+#
+# Reads benchstat output produced by `benchstat -alpha 0.05 base.txt pr.txt`
+# (modern golang.org/x/perf benchstat) and exits non-zero if any row in the
+# sec/op or allocs/op tables shows a delta worse than REGRESSION_THRESHOLD_PCT
+# with p-value below P_VALUE_MAX. B/op is advisory only.
+#
+# Usage: scripts/bench_gate.sh diff.txt
+#
+# Env:
+#   REGRESSION_THRESHOLD_PCT  default 10
+#   P_VALUE_MAX               default 0.05
+#
+# benchstat tables look like:
+#         │ base.txt   │              pr.txt              │
+#         │   sec/op   │   sec/op     vs base             │
+#   Foo-4    1.001µ ± 1%  1.502µ ± 1%  +50.00% (p=0.002 n=6)
+#   Bar-4    501.5n ± 2%  501.5n ± 2%        ~ (p=1.000 n=6)
+# A "~" delta or no p-value means no significant comparison: ignored.
+# Section is identified by the second header line containing "sec/op" or
+# "allocs/op" or "B/op".
+
+set -uo pipefail
+
+DIFF_FILE="${1:-diff.txt}"
+THRESHOLD="${REGRESSION_THRESHOLD_PCT:-10}"
+PVAL_MAX="${P_VALUE_MAX:-0.05}"
+
+if [[ ! -s "$DIFF_FILE" ]]; then
+    echo "bench_gate: diff file '$DIFF_FILE' missing or empty" >&2
+    exit 1
+fi
+
+awk -v threshold="$THRESHOLD" -v pval_max="$PVAL_MAX" '
+    BEGIN { fail = 0; section = ""; rows = 0 }
+
+    # Skip empty/whitespace-only lines.
+    /^[[:space:]]*$/ { next }
+
+    # Section header detection. benchstat prints two header lines per table;
+    # the second one names the metric. Box-drawing char │ separates columns.
+    /sec\/op/   { section = "sec";    next }
+    /allocs\/op/ { section = "allocs"; next }
+    /B\/op/      { section = "bytes";  next }
+
+    # Footnotes start with a digit-superscript char like ¹ — skip.
+    /^[[:space:]]*¹/ { next }
+
+    # geomean rows are summary aggregates; ignore.
+    /^[[:space:]]*geomean/ { next }
+
+    # We only enforce sec/op and allocs/op.
+    section != "sec" && section != "allocs" { next }
+
+    # A data row begins with a benchmark name token (no leading whitespace
+    # or a small amount); contains a "vs base" column with a delta.
+    {
+        # Find delta-pct and p-value tokens.
+        delta_pct = ""
+        pval = ""
+        for (i = 1; i <= NF; i++) {
+            if ($i ~ /^[-+][0-9]+\.[0-9]+%$/) {
+                delta_pct = $i
+            } else if ($i == "~") {
+                delta_pct = "~"
+            }
+            if ($i ~ /^\(p=/) {
+                pv = $i
+                gsub(/[\(\)p=]/, "", pv)
+                pval = pv
+            }
+        }
+
+        # No delta column means this is not a data row (header noise).
+        if (delta_pct == "") next
+
+        rows++
+
+        # Insignificant comparison.
+        if (delta_pct == "~") next
+
+        sign = substr(delta_pct, 1, 1)
+        num  = substr(delta_pct, 2, length(delta_pct) - 2) + 0
+        if (sign == "-") num = -num
+
+        # Negative or small positive deltas are not regressions.
+        if (num < threshold) next
+
+        pv = (pval == "" ? 1 : pval + 0)
+        if (pv > pval_max) next
+
+        printf("REGRESSION %s [%s]: %s (p=%s)\n", $1, section, delta_pct, pval) > "/dev/stderr"
+        fail = 1
+    }
+
+    END {
+        if (rows == 0) {
+            print "bench_gate: no benchmark rows parsed; check benchstat output" > "/dev/stderr"
+            exit 2
+        }
+        exit fail
+    }
+' "$DIFF_FILE"
+status=$?
+
+if (( status == 0 )); then
+    echo "bench_gate: OK (no regressions above ${THRESHOLD}% with p<${PVAL_MAX})"
+fi
+
+exit $status


### PR DESCRIPTION
## Summary

Adds Go microbenchmark infrastructure and a CI regression gate for the engine hot path, plus cache-hit-rate reporting in `cmd/agentshield-replay`. All purely additive; no rule or behavioural changes.

## What's in this PR

### Microbench harness (`9e996a5`)

- **5 bench files** with `b.ReportAllocs()` covering the hot path:
  - `internal/engine/bench_test.go`: rule-scaling (10/100/1000 rules), parallel, payload-size sub-benches
  - `internal/cache/bench_test.go` (new): serial Get/Set, GetParallel documenting the exclusive `Lock()` contention at `cache.go:82`, mixed 90/10 parallel, `CacheKeyWithFields` scaling
  - `internal/evaluate/bench_test.go` (new): cache-miss/hit/no-cache, session enrichment, parallel
  - `internal/server/bench_test.go` (new): direct handler, direct cache-hit, full HTTP via httptest, concurrent HTTP for throughput
  - `pkg/sigma/bench_test.go`: `b.ReportAllocs()` on existing 5 benches; new parallel bench
- **CI gate** (`.github/workflows/bench.yml`): new `microbench` job benchmarks PR HEAD vs base via `git worktree`, compares with `benchstat`, posts a sticky PR comment, gates with `scripts/bench_gate.sh` on ≥10% regression in sec/op or allocs/op (p<0.05).
- **Nightly heavy step** (`count=20, benchtime=2s`, no gate; produces baseline) added to existing `bench-nightly` job.
- **`docs/performance.md`**: new doc covering methodology, hardware, hot-path latency, cache hit/miss, allocations, concurrency, rule scaling, throughput, reproducibility. Cross-references and validates the existing `docs/architecture.md:328` claim.

### Replay cache hit-rate reporting (`87783fd`)

`internal/replay/runner.go` now actually wires `cache.NewVerdictCache` + `evaluator.SetCache()` in library mode (it didn't before — every prior replay run reported 0% cache hit regardless of trace data). HTTP mode reads `response.Cached` from the engine's JSON response.

- `CacheStats` struct in the report (hit count, miss count, hit rate, split p50/p95 for hits vs misses).
- CLI: `--cache-size`, `--cache-ttl`, `--no-cache` flags.
- 3 deterministic integration tests using a stub `Fetcher` (a json-tagged-skip seam in `RunConfig`): repeating-event stream → 95% hit rate, all-unique → 0%, `--no-cache` → `Enabled=false`. All pass on real rules.
- `make replay-cache-benchmark` runs all 3 published HF datasets in one shot.
- `docs/performance.md` "Cache hit rate on real agent traces" section with reproducibility command and a numbers table — cells are `_pending_` because the AgentShield CI sandbox blocks `datasets-server.huggingface.co` (per #36). Anyone with HF access can run `make replay-cache-benchmark` and fill them in.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` clean across all 16 packages
- [x] New benches compile (`go test -run='^$' -bench=. -benchmem`)
- [x] Existing benches in `pkg/sigma` and `internal/engine` continue to run
- [x] `bench_gate.sh` smoke-tested locally against synthetic 50% slowdown (fails) and base-vs-base (passes)
- [x] Replay integration tests (3) pass against real rule corpus
- [ ] First CI run on this PR will produce the actual baseline microbench numbers

## Notes

- This is part 1 of 3 splitting #45. Independent of the other two PRs.
- Workflow conflict resolved against the new CI/CD pipeline added in #46 (kept new main's env-var approach + `wait_for_health.sh`; added the new `microbench` job and a heavy nightly step).

https://claude.ai/code/session_01USd1nc52EVSf1uFNRnAPkd

---
_Generated by [Claude Code](https://claude.ai/code/session_01USd1nc52EVSf1uFNRnAPkd)_