### PR TITLE
chore: clean up golangci-lint v2 violations across the tree

### DIFF
--- a/cmd/agentshield-replay/main.go
+++ b/cmd/agentshield-replay/main.go
@@ -84,7 +84,7 @@ Supported datasets:
 
 	// Required
 	cmd.Flags().StringVar(&cfg.Dataset, "dataset", "", "HuggingFace dataset name (e.g. nlile/misc-merged-claude-code-traces-v1)")
-	cmd.MarkFlagRequired("dataset")
+	_ = cmd.MarkFlagRequired("dataset")
 
 	// Engine
 	cmd.Flags().StringVar(&cfg.RulesDir, "rules-dir", "rules/rules", "Path to Sigma rules directory")

--- a/cmd/agentshield/main.go
+++ b/cmd/agentshield/main.go
@@ -131,7 +131,7 @@ func newStatusCmd() *cobra.Command {
 				fmt.Printf("HTTP Health: ERROR - %v\n", err)
 				return nil
 			}
-			defer resp.Body.Close()
+			defer func() { _ = resp.Body.Close() }()
 
 			if resp.StatusCode == http.StatusOK {
 				var health map[string]interface{}
@@ -177,7 +177,7 @@ func newAlertsCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("connecting to store: %w", err)
 			}
-			defer st.Close()
+			defer func() { _ = st.Close() }()
 
 			// Build query
 			query := &store.AlertQuery{
@@ -400,7 +400,7 @@ func newRefineCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("connecting to store: %w", err)
 			}
-			defer st.Close()
+			defer func() { _ = st.Close() }()
 
 			// Create feedback manager
 			feedbackManager := feedback.NewFeedbackManager(st)

--- a/cmd/agentshieldbench/main.go
+++ b/cmd/agentshieldbench/main.go
@@ -412,7 +412,7 @@ func executeEvent(client *http.Client, endpoint, authToken string, tc *Testcase,
 			Reason:         fmt.Sprintf("http error: %v", err),
 		}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return ResultLine{
@@ -505,7 +505,7 @@ func writeJSONL(outputDir, suiteName string, results []ResultLine) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	w := bufio.NewWriter(f)
 	enc := json.NewEncoder(w)
@@ -514,7 +514,7 @@ func writeJSONL(outputDir, suiteName string, results []ResultLine) error {
 			return err
 		}
 	}
-	w.Flush()
+	_ = w.Flush()
 	fmt.Printf("  Results written: %s\n", path)
 	return nil
 }
@@ -530,34 +530,34 @@ func writeSummaryMarkdown(outputDir, suiteName string, m SuiteMetrics) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	w := bufio.NewWriter(f)
-	fmt.Fprintf(w, "# Benchmark Results: %s\n\n", suiteName)
-	fmt.Fprintf(w, "**Date:** %s\n\n", time.Now().Format(time.RFC3339))
-	fmt.Fprintf(w, "## Metrics\n\n")
-	fmt.Fprintf(w, "| Metric | Value |\n")
-	fmt.Fprintf(w, "|--------|-------|\n")
-	fmt.Fprintf(w, "| Total Events | %d |\n", m.Total)
-	fmt.Fprintf(w, "| Passed | %d |\n", m.Passed)
-	fmt.Fprintf(w, "| Failed | %d |\n", m.Failed)
-	fmt.Fprintf(w, "| TMPR (Tool Misuse Prevention Rate) | %.1f%% |\n", m.TMPR)
-	fmt.Fprintf(w, "| BTCR (Benign Task Completion Rate) | %.1f%% |\n", m.BTCR)
-	fmt.Fprintf(w, "| PESR (Policy Evasion Success Rate) | %.1f%% |\n", m.PESR)
-	fmt.Fprintf(w, "| Latency p50 | %.1fms |\n", m.LatencyP50)
-	fmt.Fprintf(w, "| Latency p95 | %.1fms |\n", m.LatencyP95)
+	_, _ = fmt.Fprintf(w, "# Benchmark Results: %s\n\n", suiteName)
+	_, _ = fmt.Fprintf(w, "**Date:** %s\n\n", time.Now().Format(time.RFC3339))
+	_, _ = fmt.Fprintf(w, "## Metrics\n\n")
+	_, _ = fmt.Fprintf(w, "| Metric | Value |\n")
+	_, _ = fmt.Fprintf(w, "|--------|-------|\n")
+	_, _ = fmt.Fprintf(w, "| Total Events | %d |\n", m.Total)
+	_, _ = fmt.Fprintf(w, "| Passed | %d |\n", m.Passed)
+	_, _ = fmt.Fprintf(w, "| Failed | %d |\n", m.Failed)
+	_, _ = fmt.Fprintf(w, "| TMPR (Tool Misuse Prevention Rate) | %.1f%% |\n", m.TMPR)
+	_, _ = fmt.Fprintf(w, "| BTCR (Benign Task Completion Rate) | %.1f%% |\n", m.BTCR)
+	_, _ = fmt.Fprintf(w, "| PESR (Policy Evasion Success Rate) | %.1f%% |\n", m.PESR)
+	_, _ = fmt.Fprintf(w, "| Latency p50 | %.1fms |\n", m.LatencyP50)
+	_, _ = fmt.Fprintf(w, "| Latency p95 | %.1fms |\n", m.LatencyP95)
 
 	if len(m.Failures) > 0 {
-		fmt.Fprintf(w, "\n## Failures\n\n")
-		fmt.Fprintf(w, "| Testcase | Event | Expected | Actual | Reason |\n")
-		fmt.Fprintf(w, "|----------|-------|----------|--------|--------|\n")
+		_, _ = fmt.Fprintf(w, "\n## Failures\n\n")
+		_, _ = fmt.Fprintf(w, "| Testcase | Event | Expected | Actual | Reason |\n")
+		_, _ = fmt.Fprintf(w, "|----------|-------|----------|--------|--------|\n")
 		for _, fail := range m.Failures {
-			fmt.Fprintf(w, "| %s | %s | %s | %s | %s |\n",
+			_, _ = fmt.Fprintf(w, "| %s | %s | %s | %s | %s |\n",
 				fail.TestcaseID, fail.EventID, fail.ExpectedAction, fail.ActualAction, fail.Reason)
 		}
 	}
 
-	w.Flush()
+	_ = w.Flush()
 	fmt.Printf("  Summary written: %s\n", path)
 	return nil
 }

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -60,7 +60,7 @@ func TestHandler(t *testing.T) {
 	// Mock handler that should only be called when auth succeeds
 	mockHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("success"))
+		_, _ = w.Write([]byte("success"))
 	})
 
 	wrappedHandler := middleware.Handler(mockHandler)
@@ -187,7 +187,7 @@ func TestRequireAuth(t *testing.T) {
 
 	handlerFunc := func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("authenticated"))
+		_, _ = w.Write([]byte("authenticated"))
 	}
 
 	wrappedFunc := middleware.RequireAuth(handlerFunc)
@@ -228,7 +228,7 @@ func TestChiMiddleware(t *testing.T) {
 	// Mock handler that should only be called when auth succeeds
 	mockHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("success"))
+		_, _ = w.Write([]byte("success"))
 	})
 
 	// Create Chi-style middleware
@@ -338,7 +338,7 @@ func TestChiMiddlewareHealthEndpointVariations(t *testing.T) {
 
 	mockHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("ok"))
+		_, _ = w.Write([]byte("ok"))
 	})
 
 	chiHandler := middleware.ChiMiddleware(mockHandler)

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -197,13 +197,13 @@ func CacheKeyWithFields(toolName string, args, fields map[string]string, context
 	}
 
 	h := sha256.New()
-	fmt.Fprintf(h, "tool=%s", effectiveTool)
-	fmt.Fprintf(h, "\ncontext=%s", normalizeContext(effectiveContext))
+	_, _ = fmt.Fprintf(h, "tool=%s", effectiveTool)
+	_, _ = fmt.Fprintf(h, "\ncontext=%s", normalizeContext(effectiveContext))
 	for _, k := range keys {
-		fmt.Fprintf(h, "\narg:%s=%s", k, args[k])
+		_, _ = fmt.Fprintf(h, "\narg:%s=%s", k, args[k])
 	}
 	for _, k := range fieldKeys {
-		fmt.Fprintf(h, "\nfield:%s=%s", k, fields[k])
+		_, _ = fmt.Fprintf(h, "\nfield:%s=%s", k, fields[k])
 	}
 	return hex.EncodeToString(h.Sum(nil))
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -342,9 +342,11 @@ func validateConfig(cfg *Config) error {
 
 	// SECURITY: Validate deep triage gateway URL for SSRF protection
 	if cfg.DeepTriage.Enabled && cfg.DeepTriage.GatewayURL != "" {
+		// gateway_url targeting localhost is expected for local OpenClaw; we
+		// log a warning rather than reject (operators intentionally run it
+		// locally), but only when the URL actually targets a private host.
 		if isPrivateOrLocalURL(cfg.DeepTriage.GatewayURL) {
-			// gateway_url targeting localhost is expected for local OpenClaw;
-			// only warn, don't reject (operators intentionally run it locally).
+			slog.Warn("deep_triage gateway_url targets a private/local network; allowed for local OpenClaw", "url", cfg.DeepTriage.GatewayURL)
 		}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -100,12 +100,12 @@ log_level: "invalid"
 				if err != nil {
 					t.Fatalf("creating temp file: %v", err)
 				}
-				defer os.Remove(tmpFile.Name())
+				defer func() { _ = os.Remove(tmpFile.Name()) }()
 
 				if _, err := tmpFile.WriteString(tt.configYAML); err != nil {
 					t.Fatalf("writing config file: %v", err)
 				}
-				tmpFile.Close()
+				_ = tmpFile.Close()
 				configPath = tmpFile.Name()
 			}
 
@@ -181,18 +181,18 @@ func TestApplyEnvOverrides(t *testing.T) {
 	// Clean up environment
 	defer func() {
 		for _, env := range envVars {
-			os.Unsetenv(env)
+			_ = os.Unsetenv(env)
 		}
 		for env, val := range originalEnv {
-			os.Setenv(env, val)
+			_ = os.Setenv(env, val)
 		}
 	}()
 
 	// Set test environment variables
-	os.Setenv("AGENTSHIELD_PORT", "9999")
-	os.Setenv("AGENTSHIELD_ADDR", "127.0.0.1")
-	os.Setenv("AGENTSHIELD_AUTH_TOKEN", "env-token")
-	os.Setenv("AGENTSHIELD_MODE", "audit")
+	_ = os.Setenv("AGENTSHIELD_PORT", "9999")
+	_ = os.Setenv("AGENTSHIELD_ADDR", "127.0.0.1")
+	_ = os.Setenv("AGENTSHIELD_AUTH_TOKEN", "env-token")
+	_ = os.Setenv("AGENTSHIELD_MODE", "audit")
 
 	cfg := &Config{
 		Server: ServerConfig{
@@ -230,7 +230,7 @@ func TestResolveRelativePaths(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating temp dir: %v", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	configPath := filepath.Join(tmpDir, "config.yaml")
 
@@ -494,16 +494,16 @@ func TestApplyEnvOverrides_TelemetryEndpoint(t *testing.T) {
 	}
 	defer func() {
 		for _, env := range envVars {
-			os.Unsetenv(env)
+			_ = os.Unsetenv(env)
 		}
 		for env, val := range originalEnv {
-			os.Setenv(env, val)
+			_ = os.Setenv(env, val)
 		}
 	}()
 
 	t.Run("endpoint_and_enabled_true", func(t *testing.T) {
-		os.Setenv("AGENTSHIELD_OTEL_ENDPOINT", "https://otel.test:4318")
-		os.Setenv("AGENTSHIELD_OTEL_ENABLED", "true")
+		_ = os.Setenv("AGENTSHIELD_OTEL_ENDPOINT", "https://otel.test:4318")
+		_ = os.Setenv("AGENTSHIELD_OTEL_ENABLED", "true")
 
 		cfg := &Config{}
 		applyEnvOverrides(cfg)
@@ -517,7 +517,7 @@ func TestApplyEnvOverrides_TelemetryEndpoint(t *testing.T) {
 	})
 
 	t.Run("enabled_with_1", func(t *testing.T) {
-		os.Setenv("AGENTSHIELD_OTEL_ENABLED", "1")
+		_ = os.Setenv("AGENTSHIELD_OTEL_ENABLED", "1")
 
 		cfg := &Config{}
 		applyEnvOverrides(cfg)
@@ -528,7 +528,7 @@ func TestApplyEnvOverrides_TelemetryEndpoint(t *testing.T) {
 	})
 
 	t.Run("enabled_with_false", func(t *testing.T) {
-		os.Setenv("AGENTSHIELD_OTEL_ENABLED", "false")
+		_ = os.Setenv("AGENTSHIELD_OTEL_ENABLED", "false")
 
 		cfg := &Config{}
 		cfg.Telemetry.Enabled = true // pre-set to true

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -491,8 +491,8 @@ func (d *Daemon) writePIDFile() error {
 
 	pidStr := strconv.Itoa(pid)
 	if _, err := f.WriteString(pidStr); err != nil {
-		f.Close()
-		os.Remove(d.pidFile)
+		_ = f.Close()
+		_ = os.Remove(d.pidFile)
 		return fmt.Errorf("writing PID file: %w", err)
 	}
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -450,7 +450,7 @@ func TestInitComponents(t *testing.T) {
 		// Create temporary directory with test rules
 		tmpDir := t.TempDir()
 		rulesDir := filepath.Join(tmpDir, "rules")
-		os.MkdirAll(rulesDir, 0755)
+		_ = os.MkdirAll(rulesDir, 0755)
 
 		// Create a basic Sigma rule for testing
 		ruleContent := `title: Test Rule
@@ -463,7 +463,7 @@ detection:
 level: high
 `
 		ruleFile := filepath.Join(rulesDir, "test.yml")
-		os.WriteFile(ruleFile, []byte(ruleContent), 0644)
+		_ = os.WriteFile(ruleFile, []byte(ruleContent), 0644)
 
 		dbPath := filepath.Join(tmpDir, "test.db")
 
@@ -520,7 +520,7 @@ level: high
 
 		// Clean up
 		if daemon.store != nil {
-			daemon.store.Close()
+			_ = daemon.store.Close()
 		}
 	})
 
@@ -553,7 +553,7 @@ level: high
 	t.Run("triage enabled but fails", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		rulesDir := filepath.Join(tmpDir, "rules")
-		os.MkdirAll(rulesDir, 0755)
+		_ = os.MkdirAll(rulesDir, 0755)
 		dbPath := filepath.Join(tmpDir, "test.db")
 
 		cfg := &config.Config{
@@ -604,7 +604,7 @@ level: high
 
 		// Clean up
 		if daemon.store != nil {
-			daemon.store.Close()
+			_ = daemon.store.Close()
 		}
 	})
 }
@@ -637,7 +637,7 @@ func TestShutdown(t *testing.T) {
 	t.Run("shutdown with initialized components", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		rulesDir := filepath.Join(tmpDir, "rules")
-		os.MkdirAll(rulesDir, 0755)
+		_ = os.MkdirAll(rulesDir, 0755)
 		dbPath := filepath.Join(tmpDir, "test.db")
 
 		cfg := &config.Config{
@@ -795,8 +795,8 @@ func newTestDaemon(t *testing.T, port int, modify func(*config.Config)) *Daemon 
 	t.Helper()
 	tmpDir := t.TempDir()
 	rulesDir := filepath.Join(tmpDir, "rules")
-	os.MkdirAll(rulesDir, 0755)
-	os.WriteFile(filepath.Join(rulesDir, "test.yml"), []byte("title: Test\nid: t1\ndescription: test\ndetection:\n    selection:\n        test: val\n    condition: selection\nlevel: high\n"), 0644)
+	_ = os.MkdirAll(rulesDir, 0755)
+	_ = os.WriteFile(filepath.Join(rulesDir, "test.yml"), []byte("title: Test\nid: t1\ndescription: test\ndetection:\n    selection:\n        test: val\n    condition: selection\nlevel: high\n"), 0644)
 
 	cfg := &config.Config{
 		LogLevel:       "info",
@@ -820,7 +820,7 @@ func newTestDaemon(t *testing.T, port int, modify func(*config.Config)) *Daemon 
 		t.Fatalf("initComponents: %v", err)
 	}
 	daemon.server = nil
-	t.Cleanup(func() { daemon.shutdown() })
+	t.Cleanup(func() { _ = daemon.shutdown() })
 	return daemon
 }
 
@@ -863,7 +863,7 @@ func TestShutdown_CallsTelemetryShutdown(t *testing.T) {
 			return nil
 		},
 	}
-	d.shutdown()
+	_ = d.shutdown()
 	if !called {
 		t.Error("expected telemetryShutdown to be called during shutdown")
 	}

--- a/internal/engine/bench_test.go
+++ b/internal/engine/bench_test.go
@@ -11,7 +11,7 @@ func BenchmarkEvaluate(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	testRule := `
 title: Bench Test Rule
@@ -52,7 +52,7 @@ func BenchmarkEvaluateNoMatch(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	testRule := `
 title: Bench Test Rule

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -15,7 +15,7 @@ func TestNewEngine(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating temp dir: %v", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	// Create a simple Sigma rule
 	testRule := `
@@ -80,7 +80,7 @@ func TestIsPathSafe(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating temp dir: %v", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	engine := &Engine{
 		rulesDir: tmpDir,
@@ -228,7 +228,7 @@ level: medium
 			if err != nil {
 				t.Fatalf("creating temp dir: %v", err)
 			}
-			defer os.RemoveAll(tmpDir)
+			defer func() { _ = os.RemoveAll(tmpDir) }()
 
 			rulePath := filepath.Join(tmpDir, "rule.yml")
 			if err := os.WriteFile(rulePath, []byte(tt.ruleYAML), 0644); err != nil {
@@ -355,7 +355,7 @@ func TestEvaluate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating temp dir: %v", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	// Create a test rule that matches a specific field
 	testRule := `
@@ -443,7 +443,7 @@ func TestGetStats(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating temp dir: %v", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	engine, err := NewEngine(tmpDir)
 	if err != nil {
@@ -479,7 +479,7 @@ func TestMultiFieldSelectionLogic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating temp dir: %v", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	// Create a rule with TWO required fields in the selection
 	testRule := `

--- a/internal/engine/regression_test.go
+++ b/internal/engine/regression_test.go
@@ -74,7 +74,7 @@ func TestEvaluateConcurrentSafety(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	testRule := `
 title: Concurrent Test Rule
@@ -129,7 +129,7 @@ func TestEvaluateSnapshotIsolation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	testRule := `
 title: Snapshot Test Rule

--- a/internal/evaluate/evaluate_integration_test.go
+++ b/internal/evaluate/evaluate_integration_test.go
@@ -113,7 +113,7 @@ level: high
 	}
 
 	// ── Phase 3: Verify OTel spans ──────────────────────────────────────
-	tp.ForceFlush(ctx)
+	_ = tp.ForceFlush(ctx)
 	spans := spanRecorder.Ended()
 	if len(spans) < 4 {
 		t.Errorf("expected at least 4 spans (3 recon + 1 exfil), got %d", len(spans))

--- a/internal/evaluate/evaluate_test.go
+++ b/internal/evaluate/evaluate_test.go
@@ -363,7 +363,7 @@ func TestEvaluateWithContext_EmitsSpan(t *testing.T) {
 		t.Fatal("expected non-empty action")
 	}
 
-	tp.ForceFlush(ctx)
+	_ = tp.ForceFlush(ctx)
 
 	spans := spanRecorder.Ended()
 	if len(spans) == 0 {
@@ -405,8 +405,8 @@ func TestEvaluateWithContext_SpanEvents_RuleMatches(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	evaluator.EvaluateWithContext(ctx, req)
-	tp.ForceFlush(ctx)
+	_, _ = evaluator.EvaluateWithContext(ctx, req)
+	_ = tp.ForceFlush(ctx)
 
 	spans := spanRecorder.Ended()
 	if len(spans) == 0 {
@@ -464,13 +464,13 @@ func TestEvaluateWithContext_SpanEvents_CacheHit(t *testing.T) {
 	ctx := context.Background()
 
 	// First call populates the cache
-	evaluator.EvaluateWithContext(ctx, req)
-	tp.ForceFlush(ctx)
+	_, _ = evaluator.EvaluateWithContext(ctx, req)
+	_ = tp.ForceFlush(ctx)
 
 	// Second call should hit the cache
 	req.EventID = "evt-004" // different event ID, same tool+args
-	evaluator.EvaluateWithContext(ctx, req)
-	tp.ForceFlush(ctx)
+	_, _ = evaluator.EvaluateWithContext(ctx, req)
+	_ = tp.ForceFlush(ctx)
 
 	spans := spanRecorder.Ended()
 	if len(spans) < 2 {
@@ -645,7 +645,7 @@ func TestEvaluateWithContext_InjectsSessionFields(t *testing.T) {
 		Tool:      "curl",
 		Fields:    map[string]string{"tool": "curl"},
 	}
-	evaluator.EvaluateWithContext(context.Background(), req)
+	_, _ = evaluator.EvaluateWithContext(context.Background(), req)
 
 	if captured["session.recent_tools"] != "ls,cat" {
 		t.Errorf("expected session.recent_tools='ls,cat', got %q", captured["session.recent_tools"])
@@ -717,8 +717,8 @@ func TestEvaluateWithContext_SpanIncludesSessionFields(t *testing.T) {
 		Tool:      "curl",
 		Fields:    map[string]string{"tool": "curl"},
 	}
-	evaluator.EvaluateWithContext(context.Background(), req)
-	tp.ForceFlush(context.Background())
+	_, _ = evaluator.EvaluateWithContext(context.Background(), req)
+	_ = tp.ForceFlush(context.Background())
 
 	spans := spanRecorder.Ended()
 	if len(spans) == 0 {
@@ -753,7 +753,7 @@ func TestEvaluateWithContext_RecordsToSessionAfterEval(t *testing.T) {
 		Tool:      "bash",
 		Fields:    map[string]string{"tool": "bash"},
 	}
-	evaluator.EvaluateWithContext(context.Background(), req)
+	_, _ = evaluator.EvaluateWithContext(context.Background(), req)
 
 	window := registry.Get("sess-rec")
 	if window == nil {

--- a/internal/feedback/feedback_test.go
+++ b/internal/feedback/feedback_test.go
@@ -16,7 +16,7 @@ func TestSubmitFeedback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create test store: %v", err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 
 	fm := NewFeedbackManager(st)
 
@@ -209,7 +209,7 @@ func TestGetRuleStatsComputesRatesFromStoreData(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create test store: %v", err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 
 	// 4 alerts total for the same rule.
 	alerts := []*store.Alert{
@@ -269,7 +269,7 @@ func TestGetRuleStats(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create test store: %v", err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 
 	// Add some test alerts
 	alerts := []*store.Alert{
@@ -340,7 +340,7 @@ func TestFeedbackSummary(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create test store: %v", err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 
 	fm := NewFeedbackManager(st)
 
@@ -370,7 +370,7 @@ func TestGetFeedbackForRule(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create test store: %v", err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 
 	fm := NewFeedbackManager(st)
 
@@ -448,7 +448,7 @@ func TestGetRuleFalsePositiveRate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create test store: %v", err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 
 	fm := NewFeedbackManager(st)
 
@@ -494,7 +494,7 @@ func TestGetHighFalsePositiveRules(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create test store: %v", err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 
 	fm := NewFeedbackManager(st)
 
@@ -513,10 +513,9 @@ func TestGetHighFalsePositiveRules(t *testing.T) {
 				t.Error("Expected non-nil rules slice")
 			}
 
-			// Should return slice (even if empty)
-			if len(rules) < 0 {
-				t.Error("Expected valid rules slice length")
-			}
+			// Should return slice (even if empty); rules == nil also acceptable.
+			// Original assertion `len(rules) < 0` was a vacuous tautology.
+			_ = rules
 
 			// Verify structure of returned rules
 			for _, rule := range rules {
@@ -536,7 +535,7 @@ func TestGetFeedbackSummaryWithData(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create test store: %v", err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 
 	fm := NewFeedbackManager(st)
 
@@ -594,7 +593,7 @@ func TestGetRuleStatsPlaceholderValues(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create test store: %v", err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 
 	fm := NewFeedbackManager(st)
 
@@ -635,7 +634,7 @@ func TestSubmitFeedbackIDGeneration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create test store: %v", err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 
 	fm := NewFeedbackManager(st)
 
@@ -685,7 +684,7 @@ func TestSubmitFeedbackTimestampHandling(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create test store: %v", err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 
 	fm := NewFeedbackManager(st)
 

--- a/internal/feedback/refinement_test.go
+++ b/internal/feedback/refinement_test.go
@@ -17,7 +17,7 @@ func TestDetermineRecommendedAction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create test store: %v", err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 
 	fm := NewFeedbackManager(st)
 	re := NewRefinementEngine(fm, "/tmp", nil)
@@ -48,7 +48,7 @@ func TestGenerateSuggestions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create test store: %v", err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 
 	fm := NewFeedbackManager(st)
 	re := NewRefinementEngine(fm, "/tmp", nil)
@@ -117,7 +117,7 @@ func TestValidateRuleFilePath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	rulesDir := filepath.Join(tmpDir, "rules")
 	err = os.MkdirAll(rulesDir, 0755)
@@ -129,7 +129,7 @@ func TestValidateRuleFilePath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create test store: %v", err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 
 	fm := NewFeedbackManager(st)
 	re := NewRefinementEngine(fm, rulesDir, nil)
@@ -181,7 +181,7 @@ func TestValidateRuleYAML(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create test store: %v", err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 
 	fm := NewFeedbackManager(st)
 	re := NewRefinementEngine(fm, "/tmp", nil)
@@ -234,7 +234,7 @@ func TestAnalyzeFalsePositivePatterns(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create test store: %v", err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 
 	// Add test alerts
 	alerts := []*store.Alert{
@@ -312,7 +312,7 @@ func TestFindRuleFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	rulesDir := filepath.Join(tmpDir, "rules")
 	err = os.MkdirAll(rulesDir, 0755)
@@ -346,7 +346,7 @@ severity: medium
 	if err != nil {
 		t.Fatalf("Failed to create test store: %v", err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 
 	fm := NewFeedbackManager(st)
 	re := NewRefinementEngine(fm, rulesDir, nil)
@@ -385,7 +385,7 @@ func TestRefinementResult(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create test store: %v", err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 
 	// Add test alerts
 	alert := &store.Alert{
@@ -408,7 +408,7 @@ func TestRefinementResult(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	// Create a test rule file
 	testRule := `

--- a/internal/feedback/regression_test.go
+++ b/internal/feedback/regression_test.go
@@ -47,7 +47,7 @@ func TestApplyRefinementPathValidationBeforeIO(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	rulesDir := filepath.Join(tmpDir, "rules")
 	if err := os.MkdirAll(rulesDir, 0755); err != nil {
@@ -82,7 +82,7 @@ detection:
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 
 	fm := NewFeedbackManager(st)
 	re := NewRefinementEngine(fm, rulesDir, nil)
@@ -107,7 +107,7 @@ func TestApplyRefinementBackupFilePermissions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	rulesDir := filepath.Join(tmpDir, "rules")
 	if err := os.MkdirAll(rulesDir, 0755); err != nil {
@@ -132,7 +132,7 @@ detection:
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 
 	fm := NewFeedbackManager(st)
 	re := NewRefinementEngine(fm, rulesDir, nil)

--- a/internal/replay/adapter_wildclaw.go
+++ b/internal/replay/adapter_wildclaw.go
@@ -2,7 +2,6 @@ package replay
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 // WildClawAdapter parses the sammshen/wildclaw-opus-traces dataset.
@@ -175,15 +174,3 @@ func init() {
 	var _ TraceAdapter = (*WildClawAdapter)(nil)
 }
 
-// wildclaw sessionID extraction helper
-func wildclaw_sessionID(row map[string]interface{}) string {
-	if meta, ok := row["task_metadata"].(map[string]interface{}); ok {
-		if id, ok := meta["task_id"].(string); ok {
-			return id
-		}
-	}
-	if id, ok := row["request_id"].(string); ok {
-		return id
-	}
-	return fmt.Sprintf("wildclaw-%d", row["row_idx"])
-}

--- a/internal/replay/fetcher.go
+++ b/internal/replay/fetcher.go
@@ -65,7 +65,7 @@ func (f *HFFetcher) FetchPage(offset int) ([]TraceRow, int, error) {
 	if err != nil {
 		return nil, 0, fmt.Errorf("HF API request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))

--- a/internal/replay/fetcher_test.go
+++ b/internal/replay/fetcher_test.go
@@ -24,7 +24,7 @@ func TestHFFetcher_FetchPage(t *testing.T) {
 			NumRows: 100,
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer server.Close()
 
@@ -61,7 +61,7 @@ func TestHFFetcher_FetchPage(t *testing.T) {
 func TestHFFetcher_FetchPage_Error(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
-		w.Write([]byte("dataset not found"))
+		_, _ = w.Write([]byte("dataset not found"))
 	}))
 	defer server.Close()
 

--- a/internal/replay/runner.go
+++ b/internal/replay/runner.go
@@ -178,7 +178,7 @@ func evaluateHTTP(client *http.Client, endpoint, token string, req *models.Evalu
 	if err != nil {
 		return "", nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))

--- a/internal/replay/runner_test.go
+++ b/internal/replay/runner_test.go
@@ -56,7 +56,7 @@ func TestRun_LibraryMode_SmallFixture(t *testing.T) {
 			NumRows: 2,
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer server.Close()
 

--- a/internal/server/security_test.go
+++ b/internal/server/security_test.go
@@ -22,7 +22,7 @@ func TestToolNameCommandValidation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating test store: %v", err)
 	}
-	defer testStore.Close()
+	defer func() { _ = testStore.Close() }()
 
 	cfg := &config.Config{}
 	mockEngine := &mockRuleEngine{}
@@ -76,7 +76,7 @@ func TestRawParamsValidationBypass(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating test store: %v", err)
 	}
-	defer testStore.Close()
+	defer func() { _ = testStore.Close() }()
 
 	cfg := &config.Config{}
 	mockEngine := &mockRuleEngine{}
@@ -109,7 +109,7 @@ func TestHealthEndpointNoConfigLeak(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating test store: %v", err)
 	}
-	defer testStore.Close()
+	defer func() { _ = testStore.Close() }()
 
 	cfg := &config.Config{
 		EvaluationMode: config.ModeEnforce,
@@ -156,7 +156,7 @@ func TestSecurityHeadersPresent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating test store: %v", err)
 	}
-	defer testStore.Close()
+	defer func() { _ = testStore.Close() }()
 
 	cfg := &config.Config{}
 	mockEngine := &mockRuleEngine{}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -887,7 +887,7 @@ func (s *Server) handleLifecycleEvent(w http.ResponseWriter, r *http.Request) {
 // handleAcceptedEvent validates JSON shape and returns 202 Accepted.
 func (s *Server) handleAcceptedEvent(w http.ResponseWriter, r *http.Request, kind string) {
 	r.Body = http.MaxBytesReader(w, r.Body, MaxRequestBodySize)
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	var payload map[string]interface{}
 	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
@@ -924,7 +924,7 @@ func (s *Server) handleOverride(w http.ResponseWriter, r *http.Request) {
 	}
 
 	r.Body = http.MaxBytesReader(w, r.Body, MaxRequestBodySize)
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	var req OverrideRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {

--- a/internal/server/server_edge_cases_test.go
+++ b/internal/server/server_edge_cases_test.go
@@ -525,7 +525,7 @@ func TestHandleAlertsEdgeCases(t *testing.T) {
 	mockEngine := &mockRuleEngine{}
 	evaluator := evaluate.NewEvaluator(mockEngine, config.ModeEnforce, "", nil, nil)
 	testStore, _ := store.NewStore(":memory:")
-	defer testStore.Close()
+	defer func() { _ = testStore.Close() }()
 
 	server, _ := NewServer(cfg, evaluator, testStore, nil)
 
@@ -737,7 +737,7 @@ func TestHandleEvaluateAdversarialInputs(t *testing.T) {
 	}
 	evaluator := evaluate.NewEvaluator(mockEngine, config.ModeEnforce, "", nil, nil)
 	testStore, _ := store.NewStore(":memory:")
-	defer testStore.Close()
+	defer func() { _ = testStore.Close() }()
 
 	server, _ := NewServer(cfg, evaluator, testStore, nil)
 
@@ -852,7 +852,7 @@ func TestHandleEvaluateConcurrency(t *testing.T) {
 	}
 	evaluator := evaluate.NewEvaluator(mockEngine, config.ModeEnforce, "", nil, nil)
 	testStore, _ := store.NewStore(":memory:")
-	defer testStore.Close()
+	defer func() { _ = testStore.Close() }()
 
 	server, _ := NewServer(cfg, evaluator, testStore, nil)
 
@@ -897,7 +897,7 @@ func TestHandleFeedbackEdgeCases(t *testing.T) {
 	mockEngine := &mockRuleEngine{}
 	evaluator := evaluate.NewEvaluator(mockEngine, config.ModeEnforce, "", nil, nil)
 	testStore, _ := store.NewStore(":memory:")
-	defer testStore.Close()
+	defer func() { _ = testStore.Close() }()
 
 	// Insert a test alert for feedback tests
 	testAlert := &store.Alert{

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -63,7 +63,7 @@ func TestHandleEvaluate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating test store: %v", err)
 	}
-	defer testStore.Close()
+	defer func() { _ = testStore.Close() }()
 
 	cfg := &config.Config{
 		EvaluationMode: config.ModeAudit,
@@ -180,7 +180,7 @@ func TestHandleEvaluateBodyTooLarge(t *testing.T) {
 	mockEngine := &mockRuleEngine{}
 	evaluator := evaluate.NewEvaluator(mockEngine, config.ModeAudit, "", nil, nil)
 	testStore, _ := store.NewStore(":memory:")
-	defer testStore.Close()
+	defer func() { _ = testStore.Close() }()
 
 	server, err := NewServer(cfg, evaluator, testStore, nil)
 	if err != nil {
@@ -209,7 +209,7 @@ func TestHandleHealth(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating test store: %v", err)
 	}
-	defer testStore.Close()
+	defer func() { _ = testStore.Close() }()
 
 	cfg := &config.Config{
 		EvaluationMode: config.ModeEnforce,
@@ -286,7 +286,7 @@ func TestHandleAlerts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating test store: %v", err)
 	}
-	defer testStore.Close()
+	defer func() { _ = testStore.Close() }()
 
 	// Insert test alerts
 	testAlert := &store.Alert{
@@ -403,7 +403,7 @@ func TestHandleFeedbackPost(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating test store: %v", err)
 	}
-	defer testStore.Close()
+	defer func() { _ = testStore.Close() }()
 
 	// Insert a test alert so feedback can find the rule name
 	testAlert := &store.Alert{
@@ -486,7 +486,7 @@ func TestHandleFeedbackGet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating test store: %v", err)
 	}
-	defer testStore.Close()
+	defer func() { _ = testStore.Close() }()
 
 	cfg := &config.Config{}
 	mockEngine := &mockRuleEngine{}
@@ -561,7 +561,7 @@ func TestHandleAuditAndLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating test store: %v", err)
 	}
-	defer testStore.Close()
+	defer func() { _ = testStore.Close() }()
 
 	cfg := &config.Config{}
 	mockEngine := &mockRuleEngine{}
@@ -624,27 +624,24 @@ func TestNewServer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating test store: %v", err)
 	}
-	defer testStore.Close()
+	defer func() { _ = testStore.Close() }()
 
 	mockEngine := &mockRuleEngine{}
 	evaluator := evaluate.NewEvaluator(mockEngine, config.ModeAudit, "", nil, nil)
 	server, err := NewServer(cfg, evaluator, testStore, nil)
 	if err != nil {
-		t.Errorf("NewServer() failed: %v", err)
+		t.Fatalf("NewServer() failed: %v", err)
 	}
-
 	if server == nil {
-		t.Error("NewServer() returned nil")
+		t.Fatal("NewServer() returned nil")
 	}
 
 	if server.config != cfg {
 		t.Error("Server config not set correctly")
 	}
-
 	if server.evaluator != evaluator {
 		t.Error("Server evaluator not set correctly")
 	}
-
 	if server.store != testStore {
 		t.Error("Server store not set correctly")
 	}
@@ -660,7 +657,7 @@ func TestNewServerWithoutAuth(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating test store: %v", err)
 	}
-	defer testStore.Close()
+	defer func() { _ = testStore.Close() }()
 
 	mockEngine := &mockRuleEngine{}
 	evaluator := evaluate.NewEvaluator(mockEngine, config.ModeAudit, "", nil, nil)
@@ -680,7 +677,7 @@ func TestRequestLogger(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating test store: %v", err)
 	}
-	defer testStore.Close()
+	defer func() { _ = testStore.Close() }()
 
 	cfg := &config.Config{}
 	mockEngine := &mockRuleEngine{}
@@ -694,7 +691,7 @@ func TestRequestLogger(t *testing.T) {
 	// Create a test handler that the logger will wrap
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("test response"))
+		_, _ = w.Write([]byte("test response"))
 	})
 
 	// Wrap with request logger
@@ -725,7 +722,7 @@ func TestHandleHealthDegraded(t *testing.T) {
 		t.Fatalf("creating test store: %v", err)
 	}
 	// Close the store to make it fail health checks
-	testStore.Close()
+	_ = testStore.Close()
 
 	cfg := &config.Config{
 		EvaluationMode: config.ModeEnforce,
@@ -767,7 +764,7 @@ func TestHandleAlertsWithFilters(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating test store: %v", err)
 	}
-	defer testStore.Close()
+	defer func() { _ = testStore.Close() }()
 
 	// Insert multiple test alerts with different properties
 	now := time.Now()
@@ -954,7 +951,7 @@ func TestHandleFeedbackSubmissionErrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating test store: %v", err)
 	}
-	defer testStore.Close()
+	defer func() { _ = testStore.Close() }()
 
 	cfg := &config.Config{}
 	mockEngine := &mockRuleEngine{}
@@ -1019,7 +1016,7 @@ func TestHandleFeedbackQueryWithLimits(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating test store: %v", err)
 	}
-	defer testStore.Close()
+	defer func() { _ = testStore.Close() }()
 
 	cfg := &config.Config{}
 	mockEngine := &mockRuleEngine{}
@@ -1104,7 +1101,7 @@ func TestHandleEvaluateFieldMapping(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating test store: %v", err)
 	}
-	defer testStore.Close()
+	defer func() { _ = testStore.Close() }()
 
 	cfg := &config.Config{}
 
@@ -1167,7 +1164,7 @@ func TestHandleEvaluatePluginPayloadPreservesEventSemantics(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating test store: %v", err)
 	}
-	defer testStore.Close()
+	defer func() { _ = testStore.Close() }()
 
 	cfg := &config.Config{}
 	mockEngine := &mockFieldCapturingEngine{
@@ -1227,7 +1224,7 @@ func TestHandleAlertsRejectsInvalidTimeFilters(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating test store: %v", err)
 	}
-	defer testStore.Close()
+	defer func() { _ = testStore.Close() }()
 
 	cfg := &config.Config{}
 	evaluator := evaluate.NewEvaluator(&mockRuleEngine{}, config.ModeAudit, "", nil, nil)
@@ -1252,7 +1249,7 @@ func TestStartAndShutdown(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating test store: %v", err)
 	}
-	defer testStore.Close()
+	defer func() { _ = testStore.Close() }()
 
 	cfg := &config.Config{
 		Server: config.ServerConfig{
@@ -1315,14 +1312,14 @@ func TestServerConfigMethods(t *testing.T) {
 
 func TestServer_SetTracerProvider(t *testing.T) {
 	tp := sdktrace.NewTracerProvider()
-	defer tp.Shutdown(context.Background())
+	defer func() { _ = tp.Shutdown(context.Background()) }()
 
 	cfg := &config.Config{}
 	testStore, err := store.NewStore(":memory:")
 	if err != nil {
 		t.Fatalf("creating test store: %v", err)
 	}
-	defer testStore.Close()
+	defer func() { _ = testStore.Close() }()
 
 	evaluator := evaluate.NewEvaluator(&mockRuleEngine{}, config.ModeEnforce, "", nil, nil)
 	srv, err := NewServer(cfg, evaluator, testStore, nil)
@@ -1349,7 +1346,7 @@ func TestServer_StartWithTracerProvider(t *testing.T) {
 	// Verify that Start() succeeds when a TracerProvider is configured
 	// (i.e. the otelchi middleware is wired in without panics).
 	tp := sdktrace.NewTracerProvider()
-	defer tp.Shutdown(context.Background())
+	defer func() { _ = tp.Shutdown(context.Background()) }()
 
 	cfg := &config.Config{
 		Server: config.ServerConfig{
@@ -1362,7 +1359,7 @@ func TestServer_StartWithTracerProvider(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating test store: %v", err)
 	}
-	defer testStore.Close()
+	defer func() { _ = testStore.Close() }()
 
 	evaluator := evaluate.NewEvaluator(&mockRuleEngine{}, config.ModeAudit, "", nil, nil)
 	srv, err := NewServer(cfg, evaluator, testStore, nil)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -3,7 +3,6 @@ package store
 import (
 	"database/sql"
 	"fmt"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -44,12 +43,9 @@ type Store struct {
 
 // NewStore creates a new store instance and initializes the database
 func NewStore(dbPath string) (*Store, error) {
-	// Create directory if it doesn't exist
-	dir := filepath.Dir(dbPath)
-	if dir != "." && dir != "" {
-		// Note: In production, you might want to create the directory
-		// but for security, we'll just validate it exists
-	}
+	// Note: caller is responsible for ensuring the parent directory of
+	// dbPath exists; we deliberately do not create it here so the code
+	// works the same in `:memory:` and on-disk modes.
 
 	// Open database connection
 	db, err := sql.Open("sqlite", dbPath+"?_journal_mode=WAL&_timeout=5000")
@@ -70,7 +66,7 @@ func NewStore(dbPath string) (*Store, error) {
 
 	// Initialize schema
 	if err := store.initSchema(); err != nil {
-		db.Close()
+		_ = db.Close()
 		return nil, fmt.Errorf("initializing schema: %w", err)
 	}
 
@@ -147,7 +143,7 @@ func (s *Store) ensureColumn(table, column, alterSQL string) error {
 	if err != nil {
 		return fmt.Errorf("querying schema for %s: %w", table, err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	for rows.Next() {
 		var (
@@ -279,7 +275,7 @@ func (s *Store) QueryAlerts(query *AlertQuery) ([]Alert, error) {
 	if err != nil {
 		return nil, fmt.Errorf("querying alerts: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var alerts []Alert
 	for rows.Next() {
@@ -402,7 +398,7 @@ func (s *Store) GetFeedbackForRule(ruleName string, limit int) ([]Feedback, erro
 	if err != nil {
 		return nil, fmt.Errorf("querying feedback for rule %s: %w", ruleName, err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var feedbacks []Feedback
 	for rows.Next() {
@@ -494,7 +490,7 @@ func (s *Store) GetRulesWithHighFPRate(threshold float64, minAlerts int) ([]stri
 	if err != nil {
 		return nil, fmt.Errorf("querying rules with high FP rate: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var highFPRules []string
 	for rows.Next() {
@@ -533,7 +529,7 @@ func (s *Store) EnforceRetention(maxAgeDays int) (int64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("starting retention transaction: %w", err)
 	}
-	defer tx.Rollback()
+	defer func() { _ = tx.Rollback() }()
 
 	// Keep feedback table bounded too.
 	if _, err := tx.Exec("DELETE FROM feedback WHERE created_at < ?", cutoff); err != nil {
@@ -577,7 +573,7 @@ func (s *Store) GetStats() (map[string]interface{}, error) {
 	if err != nil {
 		return nil, fmt.Errorf("getting severity stats: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	severityStats := make(map[string]int64)
 	for rows.Next() {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -14,7 +14,7 @@ func TestNewStore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewStore() failed: %v", err)
 	}
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	if store == nil {
 		t.Fatal("NewStore() returned nil")
@@ -25,14 +25,14 @@ func TestNewStore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating temp dir: %v", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	dbPath := filepath.Join(tmpDir, "test.db")
 	fileStore, err := NewStore(dbPath)
 	if err != nil {
 		t.Fatalf("NewStore() with file failed: %v", err)
 	}
-	defer fileStore.Close()
+	defer func() { _ = fileStore.Close() }()
 
 	// Verify database file was created
 	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
@@ -45,7 +45,7 @@ func TestInsertAlert(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating test store: %v", err)
 	}
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	alert := &Alert{
 		RuleName:    "test-rule",
@@ -95,7 +95,7 @@ func TestQueryAlerts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating test store: %v", err)
 	}
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	// Insert test data
 	now := time.Now()
@@ -233,7 +233,7 @@ func TestCountAlerts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating test store: %v", err)
 	}
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	// Insert test data
 	alerts := []*Alert{
@@ -294,7 +294,7 @@ func TestInsertFeedback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating test store: %v", err)
 	}
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	// Insert a test alert first
 	alert := &Alert{
@@ -326,7 +326,7 @@ func TestGetFeedbackForRule(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating test store: %v", err)
 	}
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	// Insert test alerts first
 	alerts := []*Alert{
@@ -407,7 +407,7 @@ func TestGetRuleFPRate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating test store: %v", err)
 	}
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	// Insert test alerts first
 	alerts := []*Alert{
@@ -478,7 +478,7 @@ func TestGetRulesWithHighFPRate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating test store: %v", err)
 	}
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	// Insert test feedback data using the actual API
 	// InsertFeedback(eventID string, alertID *int64, ruleName, feedbackType, comment string)
@@ -549,7 +549,7 @@ func TestGetRulesWithHighFPRateUsesTotalAlertsDenominator(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating test store: %v", err)
 	}
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	// 10 alerts for one rule.
 	var alertIDs []int64
@@ -592,7 +592,7 @@ func TestGetStats(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating test store: %v", err)
 	}
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	// Insert test data
 	now := time.Now()
@@ -654,7 +654,7 @@ func TestHealth(t *testing.T) {
 	}
 
 	// Close store and test health check on closed store
-	store.Close()
+	_ = store.Close()
 
 	err = store.Health()
 	if err == nil {
@@ -701,7 +701,7 @@ func TestSQLInjectionProtection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating test store: %v", err)
 	}
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	// Insert test data
 	alert := &Alert{

--- a/internal/triage/anthropic.go
+++ b/internal/triage/anthropic.go
@@ -57,7 +57,7 @@ type AnthropicError struct {
 // NewAnthropicProvider creates a new Anthropic provider
 func NewAnthropicProvider(cfg *config.TriageConfig) (*AnthropicProvider, error) {
 	if cfg.APIKey == "" {
-		return nil, fmt.Errorf("Anthropic API key is required")
+		return nil, fmt.Errorf("anthropic API key is required")
 	}
 
 	timeout := time.Duration(cfg.TimeoutSec) * time.Second
@@ -113,7 +113,7 @@ func (p *AnthropicProvider) Triage(ctx context.Context, triageCtx *TriageContext
 	if err != nil {
 		return nil, fmt.Errorf("making request to Anthropic: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	// Read response with size limit to prevent OOM from malicious responses
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 1*1024*1024)) // 1MB max
@@ -125,9 +125,9 @@ func (p *AnthropicProvider) Triage(ctx context.Context, triageCtx *TriageContext
 	if resp.StatusCode != http.StatusOK {
 		var anthropicErr AnthropicError
 		if json.Unmarshal(body, &anthropicErr) == nil && anthropicErr.Error.Message != "" {
-			return nil, fmt.Errorf("Anthropic API error (%d): %s", resp.StatusCode, anthropicErr.Error.Message)
+			return nil, fmt.Errorf("anthropic API error (%d): %s", resp.StatusCode, anthropicErr.Error.Message)
 		}
-		return nil, fmt.Errorf("Anthropic API error (%d): %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("anthropic API error (%d): %s", resp.StatusCode, string(body))
 	}
 
 	// Parse response
@@ -137,7 +137,7 @@ func (p *AnthropicProvider) Triage(ctx context.Context, triageCtx *TriageContext
 	}
 
 	if len(anthropicResp.Content) == 0 {
-		return nil, fmt.Errorf("no content in Anthropic response")
+		return nil, fmt.Errorf("no content in anthropic response")
 	}
 
 	content := anthropicResp.Content[0].Text
@@ -190,15 +190,15 @@ func (p *AnthropicProvider) healthCheckConnectivity(ctx context.Context) error {
 
 	resp, err := p.client.Do(req)
 	if err != nil {
-		return fmt.Errorf("Anthropic connectivity check failed: %w", err)
+		return fmt.Errorf("anthropic connectivity check failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		return fmt.Errorf("Anthropic API authentication failed - check API key")
+		return fmt.Errorf("anthropic API authentication failed - check API key")
 	}
 	if resp.StatusCode >= 500 {
-		return fmt.Errorf("Anthropic API server error: %d", resp.StatusCode)
+		return fmt.Errorf("anthropic API server error: %d", resp.StatusCode)
 	}
 	return nil
 }
@@ -233,16 +233,16 @@ func (p *AnthropicProvider) healthCheckFull(ctx context.Context) error {
 
 	resp, err := p.client.Do(req)
 	if err != nil {
-		return fmt.Errorf("Anthropic health check failed: %w", err)
+		return fmt.Errorf("anthropic health check failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		return fmt.Errorf("Anthropic API authentication failed - check API key")
+		return fmt.Errorf("anthropic API authentication failed - check API key")
 	}
 
 	if resp.StatusCode >= 500 {
-		return fmt.Errorf("Anthropic API server error: %d", resp.StatusCode)
+		return fmt.Errorf("anthropic API server error: %d", resp.StatusCode)
 	}
 
 	return nil

--- a/internal/triage/deep.go
+++ b/internal/triage/deep.go
@@ -223,7 +223,7 @@ func (d *DeepTriager) investigate(ctx context.Context, alerts []engine.RuleResul
 	if err != nil {
 		return fmt.Errorf("calling openclaw gateway: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("openclaw gateway returned %d", resp.StatusCode)

--- a/internal/triage/openai.go
+++ b/internal/triage/openai.go
@@ -126,7 +126,7 @@ func (p *OpenAIProvider) Triage(ctx context.Context, triageCtx *TriageContext) (
 	if err != nil {
 		return nil, fmt.Errorf("making request to OpenAI: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	// Read response with size limit to prevent OOM from malicious responses
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 1*1024*1024)) // 1MB max
@@ -187,7 +187,7 @@ func (p *OpenAIProvider) healthCheckConnectivity(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("OpenAI connectivity check failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return fmt.Errorf("OpenAI API authentication failed - check API key")
@@ -229,7 +229,7 @@ func (p *OpenAIProvider) healthCheckFull(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("OpenAI health check failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return fmt.Errorf("OpenAI API authentication failed - check API key")

--- a/internal/triage/triage_test.go
+++ b/internal/triage/triage_test.go
@@ -215,7 +215,7 @@ func TestOpenAIProvider(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(response)
+		_ = json.NewEncoder(w).Encode(response)
 	}))
 	defer server.Close()
 
@@ -284,7 +284,7 @@ func TestAnthropicProvider(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(response)
+		_ = json.NewEncoder(w).Encode(response)
 	}))
 	defer server.Close()
 
@@ -350,7 +350,7 @@ func TestTriagerFallback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create test store: %v", err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 
 	triager, err := NewTriager(cfg, st)
 	if err != nil {
@@ -397,7 +397,7 @@ func TestNewTriager(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create test store: %v", err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 
 	tests := []struct {
 		name        string
@@ -514,7 +514,7 @@ func TestShouldTriage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create test store: %v", err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 
 	triager, err := NewTriager(cfg, st)
 	if err != nil {
@@ -576,7 +576,7 @@ func TestGetFallbackVerdict(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create test store: %v", err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 
 	triager, err := NewTriager(cfg, st)
 	if err != nil {
@@ -618,7 +618,7 @@ func TestTriagerHealthCheck(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create test store: %v", err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 
 	disabledTriager, _ := NewTriager(disabledCfg, st)
 	if disabledTriager != nil {
@@ -629,7 +629,7 @@ func TestTriagerHealthCheck(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") == "Bearer valid-key" {
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"choices":[{"message":{"content":"Test"}}]}`))
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"Test"}}]}`))
 		} else {
 			w.WriteHeader(http.StatusUnauthorized)
 		}
@@ -798,7 +798,7 @@ func TestProviderHealthChecks(t *testing.T) {
 			switch r.Header.Get("Authorization") {
 			case "Bearer valid-key":
 				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"choices":[{"message":{"content":"Test"}}]}`))
+				_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"Test"}}]}`))
 			case "Bearer server-error-key":
 				w.WriteHeader(http.StatusInternalServerError)
 			default:
@@ -849,7 +849,7 @@ func TestProviderHealthChecks(t *testing.T) {
 			switch r.Header.Get("x-api-key") {
 			case "valid-key":
 				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"content":[{"type":"text","text":"Test"}]}`))
+				_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"Test"}]}`))
 			case "server-error-key":
 				w.WriteHeader(http.StatusInternalServerError)
 			default:
@@ -902,7 +902,7 @@ func TestTriageAlertsOrchestration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create test store: %v", err)
 	}
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 
 	// Test with nil triager
 	results, err := (*Triager)(nil).TriageAlerts(context.Background(), nil, nil)
@@ -929,7 +929,7 @@ func TestTriageAlertsOrchestration(t *testing.T) {
 				},
 			},
 		}
-		json.NewEncoder(w).Encode(response)
+		_ = json.NewEncoder(w).Encode(response)
 	}))
 	defer server.Close()
 
@@ -1411,7 +1411,7 @@ func TestInvestigate(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(response)
+		_ = json.NewEncoder(w).Encode(response)
 	}))
 	defer server.Close()
 
@@ -1462,7 +1462,7 @@ func TestInvestigateErrors(t *testing.T) {
 			},
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(response)
+		_ = json.NewEncoder(w).Encode(response)
 	}))
 	defer errorServer.Close()
 
@@ -1881,7 +1881,7 @@ func TestHealthCheckConnectivityMode(t *testing.T) {
 			requestedPath = r.URL.Path
 			if r.Header.Get("Authorization") == "Bearer test-key" {
 				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"data":[{"id":"gpt-4o-mini"}]}`))
+				_, _ = w.Write([]byte(`{"data":[{"id":"gpt-4o-mini"}]}`))
 			} else {
 				w.WriteHeader(http.StatusUnauthorized)
 			}
@@ -1969,7 +1969,7 @@ func TestHealthCheckConnectivityMode(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			requestedPath = r.URL.Path
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"choices":[{"message":{"content":"Test"}}]}`))
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"Test"}}]}`))
 		}))
 		defer server.Close()
 
@@ -1999,10 +1999,10 @@ func TestHealthCheckConnectivityMode(t *testing.T) {
 	t.Run("Anthropic connectivity mode uses minimal request", func(t *testing.T) {
 		var receivedBody AnthropicRequest
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			json.NewDecoder(r.Body).Decode(&receivedBody)
+			_ = json.NewDecoder(r.Body).Decode(&receivedBody)
 			if r.Header.Get("x-api-key") == "test-key" {
 				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"content":[{"type":"text","text":"."}]}`))
+				_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"."}]}`))
 			} else {
 				w.WriteHeader(http.StatusUnauthorized)
 			}
@@ -2066,9 +2066,9 @@ func TestHealthCheckConnectivityMode(t *testing.T) {
 	t.Run("Anthropic default mode uses standard request", func(t *testing.T) {
 		var receivedBody AnthropicRequest
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			json.NewDecoder(r.Body).Decode(&receivedBody)
+			_ = json.NewDecoder(r.Body).Decode(&receivedBody)
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"content":[{"type":"text","text":"Test"}]}`))
+			_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"Test"}]}`))
 		}))
 		defer server.Close()
 
@@ -2103,7 +2103,7 @@ func TestHealthCheckConnectivityMode(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			requestedMethod = r.Method
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"choices":[{"message":{"content":"Test"}}]}`))
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"Test"}}]}`))
 		}))
 		defer server.Close()
 

--- a/pkg/sigma/date.go
+++ b/pkg/sigma/date.go
@@ -47,14 +47,14 @@ func ParseDate(s string) (Date, error) {
 	if err != nil {
 		return Date{}, fmt.Errorf("parse sigma date %q: month: %v", s, err)
 	}
-	if !(1 <= month && month <= 12) {
+	if month < 1 || month > 12 {
 		return Date{}, fmt.Errorf("parse sigma date %q: invalid month %d", s, month)
 	}
 	day, err := strconv.Atoi(parts[2])
 	if err != nil {
 		return Date{}, fmt.Errorf("parse sigma date %q: day: %v", s, err)
 	}
-	if !(1 <= day && day <= 31) {
+	if day < 1 || day > 31 {
 		return Date{}, fmt.Errorf("parse sigma date %q: invalid day %d", s, day)
 	}
 	return NewDate(year, time.Month(month), day), nil

--- a/pkg/sigma/parse.go
+++ b/pkg/sigma/parse.go
@@ -47,13 +47,6 @@ type yamlRelation struct {
 	Type RelationType `yaml:"type"`
 }
 
-type yamlLogSource struct {
-	Category   string `yaml:"category,omitempty"`
-	Product    string `yaml:"product,omitempty"`
-	Service    string `yaml:"service,omitempty"`
-	Definition string `yaml:"definition,omitempty"`
-}
-
 // ParseRule parses a single Sigma YAML document.
 func ParseRule(data []byte) (*Rule, error) {
 	docNode := new(yaml.Node)

--- a/pkg/sigma/parse_test.go
+++ b/pkg/sigma/parse_test.go
@@ -832,7 +832,7 @@ func TestBase64Permuter(t *testing.T) {
 		perms := base64permute(pstring)
 		for i := 0; i < 20; i++ {
 			pbs := base64.RawStdEncoding.EncodeToString([]byte(pstring))
-			var has bool = false
+			has := false
 			for _, p := range perms {
 				if strings.Contains(pbs, p) {
 					has = true


### PR DESCRIPTION
## Summary

Clears the golangci-lint v2 backlog on `main`. PR #46 added a strict `golangci-lint v2.11.4` check to the CI pipeline but didn't fix the violations the new linter surfaced — so every PR opened against `main` since then has failed the Lint job. This is pure lint hygiene; no behavioural changes.

This unblocks #56, #57, #58.

## What's in this PR

| Category | Count | Approach |
|---|---|---|
| errcheck | 50 | Explicit `_ =` ignore on cleanup-path calls where the error is genuinely irrelevant. `defer func() { _ = x.Close() }()` for deferred closers (intent in code, not via `//nolint`). |
| staticcheck | 13 | Mix: removed empty branches, lowercased error strings (ST1005), De Morgan rewrite (`!(1 <= x && x <= 12)` → `x < 1 \|\| x > 12`), removed a vacuous `len() < 0` assertion, fixed `var x bool = false` → `x := false`, replaced two empty-branch SSRF placeholders with proper `slog.Warn` calls or explanatory comments. |
| unused | 2 | Removed dead identifiers: `wildclaw_sessionID` helper (also a snake_case violation) and the unused `yamlLogSource` struct in `pkg/sigma/parse.go`. |

## Notable substantive changes (not pure mechanical)

- **`internal/config/config.go`**: an `if isPrivateOrLocalURL(...)` block was a no-op with only a comment. Replaced with `slog.Warn(...)` so the safety check actually emits a signal when a private gateway URL is configured.
- **`internal/store/store.go`**: an `if dir != "."` block was a no-op with only a comment. Removed and the `path/filepath` import that became unused. The comment now documents the caller's responsibility for ensuring the parent directory exists.
- **`internal/feedback/feedback_test.go`**: removed `if len(rules) < 0` — vacuous (len is unsigned). The test still records `_ = rules` so the variable isn't flagged unused.
- **`internal/server/server_test.go`**: a `NewServer()` test used `t.Errorf` then continued to dereference the possibly-nil server. Switched to `t.Fatalf` for the failure path so the linter (and a real bug) can't trip.

## Test plan

- [x] `golangci-lint run ./...` reports `0 issues`
- [x] `go vet ./...` clean
- [x] `go test ./...` passes across all 16 packages
- [x] Build all binaries

Once this lands, #56 / #57 / #58 should pass the Lint check via base-branch update — they don't add any new violations.

https://claude.ai/code/session_01USd1nc52EVSf1uFNRnAPkd

---
_Generated by [Claude Code](https://claude.ai/code/session_01USd1nc52EVSf1uFNRnAPkd)_