### PR TITLE
feat(mcp-gateway): add MCP security gateway connector

### DIFF
--- a/PLATFORMS.md
+++ b/PLATFORMS.md
@@ -18,6 +18,7 @@ Detection rules assume **Unix/POSIX command semantics** (e.g. `bash`, `chmod`, `
 |-------------|----------|--------|
 | [OpenClaw](plugins/openclaw/) | TypeScript | Production-ready |
 | [Claude Code](plugins/claude/) | Shell (Bash) | Production-ready |
+| [MCP Gateway](plugins/mcp-gateway/) | TypeScript | In development |
 | Generic HTTP API | Any | Available via `POST /api/v1/evaluate` |
 
 Any platform capable of making HTTP requests can integrate with AgentShield through the [evaluation API](docs/api.md).

--- a/plugins/mcp-gateway/.gitignore
+++ b/plugins/mcp-gateway/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.log
+.DS_Store

--- a/plugins/mcp-gateway/README.md
+++ b/plugins/mcp-gateway/README.md
@@ -1,0 +1,264 @@
+# AgentShield MCP Security Gateway
+
+A transparent security proxy for the [Model Context Protocol](https://modelcontextprotocol.io)
+(MCP). The gateway sits between an MCP **client** (the agent) and one or more
+downstream MCP **servers**, intercepts every `tools/call` request, evaluates it
+against AgentShield's [Sigma](https://sigmahq.io/)-based detection engine, and
+either **blocks** the call or **forwards** it to the downstream server.
+
+Because virtually every modern coding/agent platform speaks MCP — Claude Code,
+OpenAI Codex, Gemini CLI, Cursor, Windsurf — a single MCP gateway gives
+**near-universal enforcement coverage**, including closed platforms that expose
+no native pre-tool hook API. Where a platform has no synchronous interception
+point of its own, point it at this gateway and you get full blocking
+enforcement for any MCP tool it calls.
+
+## How it works
+
+```
+                          ┌──────────────────────────────────────────┐
+                          │            AgentShield MCP Gateway          │
+   MCP client    stdio /  │  ┌────────────┐   evaluate   ┌──────────┐  │   stdio /   ┌────────────────┐
+  (the agent) ───HTTP────▶│  │ MCP Server │──────────────▶│ Pipeline │──┼──HTTP──────▶│ AgentShield     │
+                          │  │ (upstream) │◀──block/allow─│ + breaker│  │             │ engine (Sigma)  │
+                          │  └─────┬──────┘               └────┬─────┘  │             └────────────────┘
+                          │        │ forward (if allowed)      │ audit/lifecycle (fire-and-forget)
+                          │  ┌─────▼──────┐                    │        │
+                          │  │ MCP Client │────────────────────┘        │   stdio /   ┌────────────────┐
+                          │  │(downstream)│─────────────────────────────┼──HTTP──────▶│ Downstream MCP  │
+                          │  └────────────┘                             │             │ server(s)       │
+                          └──────────────────────────────────────────┘             └────────────────┘
+```
+
+For each `tools/call` the gateway runs the canonical AgentShield connector
+pipeline (contract Section 3):
+
+1. **Normalise** the (possibly namespaced) MCP tool name and arguments into a
+   canonical name + human-readable command string (see *Tool mapping* below).
+2. **Skip** check — tools in `skip` are forwarded without evaluation.
+3. **Intercept** filter — when `intercept` is non-empty, only listed tools (by
+   original *or* canonical name) are evaluated; everything else is forwarded.
+4. **Circuit-breaker** gate — if the breaker is open, the engine is not called
+   and the `timeout_policy` is applied.
+5. **Build** the `EvaluationRequest` envelope (`source: "mcp-gateway"`).
+6. **Evaluate** synchronously via `POST /api/v1/evaluate`, timeout-bounded.
+7. **Act** on the verdict:
+   - `block` → return a tool result with `isError: true` carrying the reason.
+   - `require_approval` → **fail closed** (block); see *Enforcement model*.
+   - `log` → forward, log alerts subject to the `notify` threshold.
+   - `allow` → forward.
+8. **Audit** — after the downstream tool returns, a fire-and-forget
+   `AuditReport` is sent to `/api/v1/audit`, correlated to the evaluation.
+9. **Lifecycle** — MCP `initialize` maps to `session_start`, transport close
+   maps to `session_end`, both sent to `/api/v1/lifecycle`.
+10. **Health** — a non-blocking `GET /api/v1/health` runs at startup.
+
+`tools/list` and all other MCP requests pass through transparently; the gateway
+mirrors the downstream server's name, version, capabilities and instructions so
+the agent sees a faithful proxy.
+
+## Prerequisites
+
+- A running AgentShield engine (see the [main README](../../README.md)).
+- Node.js 20+ (the gateway uses the global `fetch` and `AbortSignal.timeout`).
+- One or more downstream MCP servers to protect.
+
+## Install
+
+```bash
+cd plugins/mcp-gateway
+npm install
+npm run build
+```
+
+## Usage
+
+### stdio (primary)
+
+The simplest deployment drops the gateway in front of an existing stdio MCP
+server command. Everything after `--` is the downstream launch command:
+
+```bash
+node dist/bin.js -- npx -y @modelcontextprotocol/server-filesystem /data
+```
+
+Wire it into any MCP client by replacing the server's `command`/`args` with the
+gateway. For example, in a client's `mcp.json` / `settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "node",
+      "args": [
+        "/abs/path/plugins/mcp-gateway/dist/bin.js",
+        "--",
+        "npx", "-y", "@modelcontextprotocol/server-filesystem", "/data"
+      ],
+      "env": {
+        "AGENTSHIELD_ENDPOINT": "http://127.0.0.1:8433/api/v1/evaluate",
+        "AGENTSHIELD_AUTH_TOKEN": "your-token"
+      }
+    }
+  }
+}
+```
+
+This pattern works for Claude Code, Codex, Gemini CLI, Cursor and Windsurf —
+any client that launches MCP servers as stdio subprocesses.
+
+### Streamable HTTP / SSE
+
+Set `serve.transport` to `http` (or `MCP_SERVE_TRANSPORT=http`) to expose the
+gateway over the MCP Streamable HTTP transport. Each agent session gets its own
+downstream connection.
+
+```bash
+MCP_SERVE_TRANSPORT=http MCP_SERVE_PORT=8434 \
+  MCP_DOWNSTREAM_TRANSPORT=http MCP_DOWNSTREAM_URL=http://localhost:7000/mcp \
+  node dist/bin.js
+```
+
+### Config file
+
+```bash
+node dist/bin.js --config ./config.example.json
+```
+
+See [`config.example.json`](config.example.json).
+
+## Configuration
+
+Configuration layers, lowest to highest precedence: **defaults < JSON file <
+environment**. Invalid values fall back to defaults silently (matching the
+sibling connectors). The `auth_token` falls back to `AGENTSHIELD_AUTH_TOKEN`
+when unset — secrets are never hard-coded.
+
+| Key | Type | Default | Env override | Validation |
+|-----|------|---------|--------------|------------|
+| `enabled` | bool | `true` | `AGENTSHIELD_ENABLED` | non-bool → default |
+| `endpoint` | string | `http://127.0.0.1:8433/api/v1/evaluate` | `AGENTSHIELD_ENDPOINT` | non-empty, trimmed |
+| `auth_token` | string | `""` | `AGENTSHIELD_AUTH_TOKEN` | falls back to env var |
+| `timeout_ms` | number | `200` | `AGENTSHIELD_TIMEOUT_MS` | `5`–`5000`, else default |
+| `timeout_policy` | enum | `block` | `AGENTSHIELD_TIMEOUT_POLICY` | `allow` \| `block` \| `log` |
+| `notify` | enum | `high` | `AGENTSHIELD_NOTIFY` | `all` \| `high` \| `critical` \| `none` |
+| `intercept` | string[] | canonical + common MCP names | — | non-string entries dropped |
+| `skip` | string[] | `["todo", "memory_search", "session_status"]` | — | non-string entries dropped |
+| `circuit_breaker.failure_threshold` | int | `3` | — | `>= 1`, else default |
+| `circuit_breaker.recovery_interval_ms` | int | `30000` | — | `>= 1000`, else default |
+| `downstream.transport` | enum | `stdio` | `MCP_DOWNSTREAM_TRANSPORT` | `stdio` \| `http` |
+| `downstream.command` | string | `null` | `MCP_DOWNSTREAM_COMMAND` | required for stdio |
+| `downstream.args` | string[] | `[]` | `MCP_DOWNSTREAM_ARGS` (space-split) | — |
+| `downstream.env` | object | `{}` | — | string values only |
+| `downstream.url` | string | `null` | `MCP_DOWNSTREAM_URL` | required for http |
+| `serve.transport` | enum | `stdio` | `MCP_SERVE_TRANSPORT` | `stdio` \| `http` |
+| `serve.host` | string | `127.0.0.1` | `MCP_SERVE_HOST` | — |
+| `serve.port` | int | `8434` | `MCP_SERVE_PORT` | `1`–`65535` |
+| (log level) | enum | `info` | `AGENTSHIELD_LOG_LEVEL` / `--log-level` | `debug`/`info`/`warn`/`error` |
+
+A downstream stdio command supplied after `--` on the CLI overrides
+`downstream.command`/`downstream.args`.
+
+## Evaluation modes
+
+The engine's `effective_mode` governs what verdicts it returns; the gateway
+honours them transparently:
+
+- **enforce** — block on critical/high, require approval on medium.
+- **audit** — alerts recorded (`log`), nothing blocked.
+- **shadow** — silent monitoring.
+
+## Enforcement model
+
+**Blocking (full enforcement).** MCP exposes a synchronous request/response for
+`tools/call`, so the gateway evaluates *before* forwarding and can deny the
+call. A blocked or approval-required call is returned to the agent as a tool
+result with `isError: true` and the human-readable reason, rather than a raw
+protocol error the client might silently retry.
+
+- `timeout_policy` defaults to **`block`** (fail-closed): if the engine is
+  unreachable, times out, returns a non-2xx, or returns an invalid `action`,
+  the call is denied. Set `timeout_policy: "allow"` to fail open.
+- **`require_approval` fails closed.** MCP has no standard interactive
+  user-approval channel from a proxied server, so the gateway treats
+  `require_approval` as a block (contract Section 3.2). The block result is
+  flagged `overridable` so a host that *does* offer an override path can surface
+  one; when a user overrides, call `POST /api/v1/override` (exposed via the
+  client) so the engine can track override escalation.
+
+## Tool mapping
+
+MCP tool names are frequently namespaced by the client (`mcp__server__tool`,
+`server.tool`, `server/tool`, `server:tool`). The gateway strips the namespace,
+then maps the bare name to an AgentShield canonical name using the same alias
+table as the Hermes connector, so the same Sigma rules fire regardless of which
+MCP server emitted the call. Unknown tools pass through unchanged.
+
+| Downstream / platform names | Canonical | `command` string |
+|---|---|---|
+| `terminal`, `execute_command`, `run_command`, `shell`, `bash` | `exec` | the raw command |
+| `write_file`, `create_file`, `save_file`, `Write` | `write` | `Write: <path>` |
+| `read_file`, `view_file`, `Read`, `cat` | `read` | `Read: <path>` |
+| `edit_file`, `patch_file`, `replace_in_file`, `Edit` | `edit` | `Edit: <path>` |
+| `web_browse`, `browser`, `navigate`, `browse_url` | `browser` | `<action>: <url>` |
+| `send_message`, `slack_send`, `telegram_send`, … | `message` | `Message to <channel>` |
+| `delegate`, `spawn_agent`, `create_subagent` | `sessions_spawn` | `Spawn: <agent>` |
+| `code_execute`, `python_execute`, `run_python` | `code_execute` | `Execute: <code…>` |
+| `web_search`, `search` | `web_search` | `Search: <query>` |
+| (others) | passthrough | the original name |
+
+`event_type` is derived independently: `read`→`file_read`, `write`/`create`→
+`file_write`, `edit`→`file_edit`, `sessions_spawn`→`session_spawn`, else
+`tool_call`.
+
+## Architecture
+
+```
+plugins/mcp-gateway/
+├── src/
+│   ├── bin.ts            # CLI entry: stdio (primary) + streamable HTTP serving
+│   ├── index.ts          # public exports + stderr logger factory
+│   ├── gateway.ts        # McpGateway: MCP Server (upstream) ↔ Client (downstream) proxy
+│   ├── pipeline.ts       # skip→intercept→breaker→evaluate→act→audit→lifecycle
+│   ├── client.ts         # AgentShieldClient: evaluate + fire-and-forget audit/lifecycle/feedback/override + health
+│   ├── event-builder.ts  # buildEvaluationRequest / buildAuditReport / buildLifecycleEvent
+│   ├── normalise.ts      # tool-name + command normalisation (alias table)
+│   ├── config.ts         # parseConfig (env + JSON) with validation; loadConfigFile
+│   ├── circuit-breaker.ts# three-state circuit breaker
+│   └── types.ts          # shared wire + config types
+├── config.example.json
+├── package.json
+├── tsconfig.json
+└── vitest.config.ts
+```
+
+### Design decisions
+
+- **Single external dependency** — only the official
+  `@modelcontextprotocol/sdk`; the engine HTTP client uses the global `fetch`.
+- **stdout stays clean** — all diagnostics go to **stderr** so they never
+  corrupt the stdio MCP framing.
+- **Faithful passthrough** — the gateway advertises the downstream server's own
+  identity and capabilities; only `tools/call` is intercepted.
+- **In-band block reasons** — denials are returned as `isError` tool results so
+  the model can read the reason and adapt, rather than treating it as a
+  transport fault.
+
+## Running tests
+
+```bash
+cd plugins/mcp-gateway
+npm test            # vitest unit tests
+npm run typecheck   # tsc --noEmit (strict)
+```
+
+## Related
+
+- Main repository: [AgentShield](../../README.md)
+- Sibling connectors: [OpenClaw](../openclaw/README.md), [Hermes](../hermes/README.md), [Claude Code](../claude/README.md)
+- Detection rules: [`rules/`](../../rules)
+- Engine API: [`docs/api.md`](../../docs/api.md)
+
+## Licence
+
+Apache 2.0 — see [LICENSE](../../LICENSE) for details.

--- a/plugins/mcp-gateway/config.example.json
+++ b/plugins/mcp-gateway/config.example.json
@@ -1,0 +1,34 @@
+{
+  "enabled": true,
+  "endpoint": "http://127.0.0.1:8433/api/v1/evaluate",
+  "auth_token": "",
+  "timeout_ms": 200,
+  "timeout_policy": "block",
+  "notify": "high",
+  "intercept": [
+    "exec",
+    "write",
+    "edit",
+    "read",
+    "browser",
+    "message",
+    "sessions_spawn",
+    "code_execute"
+  ],
+  "skip": ["todo", "memory_search", "session_status"],
+  "circuit_breaker": {
+    "failure_threshold": 3,
+    "recovery_interval_ms": 30000
+  },
+  "downstream": {
+    "transport": "stdio",
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-filesystem", "/data"],
+    "env": {}
+  },
+  "serve": {
+    "transport": "stdio",
+    "host": "127.0.0.1",
+    "port": 8434
+  }
+}

--- a/plugins/mcp-gateway/package-lock.json
+++ b/plugins/mcp-gateway/package-lock.json
@@ -1,0 +1,2441 @@
+{
+  "name": "@agentshield-ai/mcp-gateway",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@agentshield-ai/mcp-gateway",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0"
+      },
+      "bin": {
+        "agentshield-mcp-gateway": "dist/bin.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "~5.7",
+        "vitest": "^4.0.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
+      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
+      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
+      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
+      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
+      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
+      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
+      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
+      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
+      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
+      "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
+      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
+      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
+      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
+      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
+      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.7",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
+      "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.132.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.2",
+        "@rolldown/binding-darwin-arm64": "1.0.2",
+        "@rolldown/binding-darwin-x64": "1.0.2",
+        "@rolldown/binding-freebsd-x64": "1.0.2",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.2",
+        "@rolldown/binding-linux-arm64-musl": "1.0.2",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-musl": "1.0.2",
+        "@rolldown/binding-openharmony-arm64": "1.0.2",
+        "@rolldown/binding-wasm32-wasi": "1.0.2",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.2",
+        "@rolldown/binding-win32-x64-msvc": "1.0.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
+      "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.2",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/plugins/mcp-gateway/package.json
+++ b/plugins/mcp-gateway/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@agentshield-ai/mcp-gateway",
+  "version": "1.0.0",
+  "description": "AgentShield security gateway for the Model Context Protocol. A transparent proxy between an MCP client (agent) and downstream MCP servers that evaluates every tools/call against AgentShield's Sigma detection engine and blocks or forwards it.",
+  "type": "module",
+  "bin": {
+    "agentshield-mcp-gateway": "./dist/bin.js"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist/",
+    "README.md"
+  ],
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "agentshield",
+    "security",
+    "siem",
+    "ai-agent",
+    "proxy",
+    "gateway",
+    "sigma-rules"
+  ],
+  "author": "AgentShield",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/agentshield-ai/agentshield.git",
+    "directory": "plugins/mcp-gateway"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "start": "node dist/bin.js",
+    "test": "vitest run --config vitest.config.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "~5.7",
+    "vitest": "^4.0.0"
+  }
+}

--- a/plugins/mcp-gateway/src/bin.ts
+++ b/plugins/mcp-gateway/src/bin.ts
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { randomUUID } from "node:crypto";
+
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+
+import { loadConfigFile, parseConfig } from "./config.js";
+import { McpGateway } from "./gateway.js";
+import { createLogger } from "./index.js";
+import type { AgentShieldConfig, Logger } from "./types.js";
+
+/**
+ * Parse `--config <path>` / `--log-level <level>` from argv.
+ *
+ * Bare CLI args after `--` are treated as the downstream stdio launch command
+ * so the gateway can be dropped in front of an existing MCP server invocation:
+ *   agentshield-mcp-gateway -- npx -y @modelcontextprotocol/server-filesystem /data
+ */
+function parseArgs(argv: string[]): {
+  configPath?: string;
+  logLevel?: "debug" | "info" | "warn" | "error";
+  downstreamCmd?: string;
+  downstreamArgs: string[];
+} {
+  const out: {
+    configPath?: string;
+    logLevel?: "debug" | "info" | "warn" | "error";
+    downstreamCmd?: string;
+    downstreamArgs: string[];
+  } = { downstreamArgs: [] };
+
+  const dashDash = argv.indexOf("--");
+  const head = dashDash === -1 ? argv : argv.slice(0, dashDash);
+  const tail = dashDash === -1 ? [] : argv.slice(dashDash + 1);
+
+  for (let i = 0; i < head.length; i += 1) {
+    const a = head[i];
+    if (a === "--config" && i + 1 < head.length) {
+      out.configPath = head[(i += 1)];
+    } else if (a === "--log-level" && i + 1 < head.length) {
+      const lvl = head[(i += 1)];
+      if (lvl === "debug" || lvl === "info" || lvl === "warn" || lvl === "error") {
+        out.logLevel = lvl;
+      }
+    }
+  }
+
+  if (tail.length > 0) {
+    out.downstreamCmd = tail[0];
+    out.downstreamArgs = tail.slice(1);
+  }
+
+  return out;
+}
+
+async function serveStdio(config: AgentShieldConfig, logger: Logger): Promise<void> {
+  const gateway = new McpGateway(config, logger);
+  const transport = new StdioServerTransport();
+
+  const shutdown = async (): Promise<void> => {
+    logger.info("Shutting down MCP gateway");
+    await gateway.stop();
+    process.exit(0);
+  };
+  process.on("SIGINT", () => void shutdown());
+  process.on("SIGTERM", () => void shutdown());
+
+  await gateway.start(transport);
+  logger.info("AgentShield MCP gateway running on stdio");
+}
+
+/**
+ * Serve over Streamable HTTP. Each session (identified by the
+ * `mcp-session-id` header, assigned on initialize) gets its own gateway and
+ * downstream connection so multiple agents can be proxied concurrently.
+ */
+async function serveHttp(config: AgentShieldConfig, logger: Logger): Promise<void> {
+  type Session = { gateway: McpGateway; transport: StreamableHTTPServerTransport };
+  const sessions = new Map<string, Session>();
+
+  const httpServer = createServer((req: IncomingMessage, res: ServerResponse) => {
+    void handleHttp(req, res).catch((err: unknown) => {
+      logger.error(`HTTP handler error: ${String(err)}`);
+      if (!res.headersSent) {
+        res.writeHead(500).end();
+      }
+    });
+  });
+
+  async function handleHttp(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const sessionId = req.headers["mcp-session-id"] as string | undefined;
+
+    if (sessionId && sessions.has(sessionId)) {
+      await (sessions.get(sessionId) as Session).transport.handleRequest(req, res);
+      return;
+    }
+
+    if (req.method === "POST" && !sessionId) {
+      // New session: assign an id, build a gateway, and route through it.
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => randomUUID(),
+        onsessioninitialized: (id: string) => {
+          sessions.set(id, { gateway, transport });
+        },
+      });
+      transport.onclose = () => {
+        const id = transport.sessionId;
+        if (id) {
+          sessions.delete(id);
+        }
+        void gateway.stop();
+      };
+      const gateway = new McpGateway(config, logger);
+      await gateway.start(transport);
+      await transport.handleRequest(req, res);
+      return;
+    }
+
+    res.writeHead(400).end(JSON.stringify({ error: "missing or invalid mcp-session-id" }));
+  }
+
+  await new Promise<void>((resolve) => {
+    httpServer.listen(config.serve.port, config.serve.host, () => resolve());
+  });
+  logger.info(
+    `AgentShield MCP gateway listening on http://${config.serve.host}:${config.serve.port}`,
+  );
+
+  const shutdown = (): void => {
+    logger.info("Shutting down MCP gateway");
+    for (const s of sessions.values()) {
+      void s.gateway.stop();
+    }
+    httpServer.close();
+    process.exit(0);
+  };
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const logger = createLogger(args.logLevel ?? (process.env.AGENTSHIELD_LOG_LEVEL as never) ?? "info");
+
+  const fileCfg = loadConfigFile(args.configPath ?? process.env.MCP_GATEWAY_CONFIG);
+  let config = parseConfig(fileCfg);
+
+  // CLI downstream command (after `--`) overrides config for stdio downstream.
+  if (args.downstreamCmd) {
+    config = {
+      ...config,
+      downstream: {
+        ...config.downstream,
+        transport: "stdio",
+        command: args.downstreamCmd,
+        args: args.downstreamArgs,
+      },
+    };
+  }
+
+  if (!config.enabled) {
+    logger.warn("AgentShield gateway disabled by config; downstream will NOT be proxied. Exiting.");
+    process.exit(0);
+  }
+
+  if (config.serve.transport === "http") {
+    await serveHttp(config, logger);
+  } else {
+    await serveStdio(config, logger);
+  }
+}
+
+void main().catch((err: unknown) => {
+  process.stderr.write(`[agentshield] FATAL ${String(err)}\n`);
+  process.exit(1);
+});

--- a/plugins/mcp-gateway/src/circuit-breaker.test.ts
+++ b/plugins/mcp-gateway/src/circuit-breaker.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CircuitBreaker } from "./circuit-breaker.js";
+
+describe("CircuitBreaker", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts in closed state", () => {
+    const cb = new CircuitBreaker({ failureThreshold: 3, recoveryIntervalMs: 30_000 });
+    expect(cb.getState()).toBe("closed");
+    expect(cb.isOpen()).toBe(false);
+  });
+
+  it("transitions to open after threshold failures", () => {
+    const cb = new CircuitBreaker({ failureThreshold: 3, recoveryIntervalMs: 30_000 });
+    cb.recordFailure();
+    cb.recordFailure();
+    expect(cb.getState()).toBe("closed");
+    cb.recordFailure();
+    expect(cb.getState()).toBe("open");
+    expect(cb.isOpen()).toBe(true);
+  });
+
+  it("resets failure count on success", () => {
+    const cb = new CircuitBreaker({ failureThreshold: 3, recoveryIntervalMs: 30_000 });
+    cb.recordFailure();
+    cb.recordFailure();
+    cb.recordSuccess();
+    cb.recordFailure();
+    cb.recordFailure();
+    expect(cb.getState()).toBe("closed");
+    cb.recordFailure();
+    expect(cb.getState()).toBe("open");
+  });
+
+  it("transitions from open to half-open after recovery interval", () => {
+    const cb = new CircuitBreaker({ failureThreshold: 1, recoveryIntervalMs: 30_000 });
+    cb.recordFailure();
+    expect(cb.isOpen()).toBe(true);
+    vi.advanceTimersByTime(30_001);
+    expect(cb.isOpen()).toBe(false);
+    expect(cb.getState()).toBe("half-open");
+  });
+
+  it("transitions from half-open to closed on success", () => {
+    const cb = new CircuitBreaker({ failureThreshold: 1, recoveryIntervalMs: 30_000 });
+    cb.recordFailure();
+    vi.advanceTimersByTime(30_001);
+    expect(cb.isOpen()).toBe(false);
+    cb.recordSuccess();
+    expect(cb.getState()).toBe("closed");
+  });
+
+  it("transitions from half-open to open on failure", () => {
+    const cb = new CircuitBreaker({ failureThreshold: 1, recoveryIntervalMs: 30_000 });
+    cb.recordFailure();
+    vi.advanceTimersByTime(30_001);
+    expect(cb.isOpen()).toBe(false);
+    cb.recordFailure();
+    expect(cb.getState()).toBe("open");
+    expect(cb.isOpen()).toBe(true);
+  });
+
+  it("remains open before recovery interval elapses", () => {
+    const cb = new CircuitBreaker({ failureThreshold: 1, recoveryIntervalMs: 30_000 });
+    cb.recordFailure();
+    expect(cb.isOpen()).toBe(true);
+    vi.advanceTimersByTime(15_000);
+    expect(cb.isOpen()).toBe(true);
+  });
+});

--- a/plugins/mcp-gateway/src/circuit-breaker.ts
+++ b/plugins/mcp-gateway/src/circuit-breaker.ts
@@ -1,0 +1,82 @@
+import type { CircuitBreakerState } from "./types.js";
+
+export type CircuitBreakerOptions = {
+  failureThreshold: number;
+  recoveryIntervalMs: number;
+};
+
+/**
+ * Three-state circuit breaker for the AgentShield HTTP client.
+ *
+ * Identical logic to the OpenClaw and Hermes reference connectors
+ * (contract Section 5). Node is single-threaded for this proxy so no lock is
+ * required; the monotonic-vs-wall-clock distinction does not affect behaviour
+ * here as we only measure elapsed intervals.
+ *
+ * State machine:
+ *   closed    --(N consecutive failures)----------> open
+ *   open      --(recoveryIntervalMs elapsed)-------> half-open  (lazily, on read)
+ *   half-open --(success)--------------------------> closed
+ *   half-open --(failure)--------------------------> open
+ */
+export class CircuitBreaker {
+  private state: CircuitBreakerState = "closed";
+  private consecutiveFailures = 0;
+  private lastFailureTime = 0;
+  private readonly failureThreshold: number;
+  private readonly recoveryIntervalMs: number;
+
+  constructor(opts: CircuitBreakerOptions) {
+    this.failureThreshold = opts.failureThreshold;
+    this.recoveryIntervalMs = opts.recoveryIntervalMs;
+  }
+
+  /** Returns true if the circuit is open and calls should be skipped. */
+  isOpen(): boolean {
+    if (this.state === "closed") {
+      return false;
+    }
+
+    if (this.state === "open") {
+      const elapsed = Date.now() - this.lastFailureTime;
+      if (elapsed >= this.recoveryIntervalMs) {
+        this.state = "half-open";
+        return false; // Allow a single probe request through.
+      }
+      return true;
+    }
+
+    // half-open: allow the probe request through.
+    return false;
+  }
+
+  recordSuccess(): void {
+    this.consecutiveFailures = 0;
+    this.state = "closed";
+  }
+
+  recordFailure(): void {
+    this.consecutiveFailures += 1;
+    this.lastFailureTime = Date.now();
+
+    if (this.state === "half-open") {
+      this.state = "open";
+      return;
+    }
+
+    if (this.consecutiveFailures >= this.failureThreshold) {
+      this.state = "open";
+    }
+  }
+
+  getState(): CircuitBreakerState {
+    // Re-evaluate the lazy open -> half-open transition on read.
+    if (this.state === "open") {
+      const elapsed = Date.now() - this.lastFailureTime;
+      if (elapsed >= this.recoveryIntervalMs) {
+        this.state = "half-open";
+      }
+    }
+    return this.state;
+  }
+}

--- a/plugins/mcp-gateway/src/client.ts
+++ b/plugins/mcp-gateway/src/client.ts
@@ -1,0 +1,135 @@
+import type {
+  AgentShieldConfig,
+  AuditReport,
+  EvaluationRequest,
+  EvaluationResponse,
+  LifecycleEvent,
+  Logger,
+  OverrideRequest,
+} from "./types.js";
+
+const CONTRACT_VERSION = "1.0.0";
+
+const VALID_ACTIONS = new Set(["allow", "block", "log", "require_approval"]);
+
+const HEALTH_TIMEOUT_MS = 2000;
+
+/**
+ * HTTP client for the AgentShield engine API (contract Section 1).
+ *
+ * - `evaluate()` is synchronous (awaited) with a configurable timeout.
+ * - `sendAudit()`, `sendLifecycle()`, `submitFeedback()`, `sendOverride()` are
+ *   fire-and-forget; failures are swallowed at debug level.
+ * - The evaluate endpoint is configured; the others are derived by stripping
+ *   the trailing `/evaluate` (Section 1).
+ */
+export class AgentShieldClient {
+  private readonly endpoint: string;
+  private readonly auditEndpoint: string;
+  private readonly lifecycleEndpoint: string;
+  private readonly healthEndpoint: string;
+  private readonly feedbackEndpoint: string;
+  private readonly overrideEndpoint: string;
+  private readonly timeoutMs: number;
+  private readonly authToken: string;
+  private readonly logger: Logger;
+
+  constructor(config: AgentShieldConfig, logger: Logger) {
+    this.endpoint = config.endpoint;
+    const baseUrl = config.endpoint.replace(/\/evaluate$/, "");
+    this.auditEndpoint = `${baseUrl}/audit`;
+    this.lifecycleEndpoint = `${baseUrl}/lifecycle`;
+    this.healthEndpoint = `${baseUrl}/health`;
+    this.feedbackEndpoint = `${baseUrl}/feedback`;
+    this.overrideEndpoint = `${baseUrl}/override`;
+    this.timeoutMs = config.timeout_ms;
+    this.authToken = config.auth_token;
+    this.logger = logger;
+  }
+
+  /** Synchronous, awaited, timeout-bounded evaluation (contract Section 1.1). */
+  async evaluate(request: EvaluationRequest): Promise<EvaluationResponse> {
+    const response = await fetch(this.endpoint, {
+      method: "POST",
+      headers: this.buildHeaders(),
+      body: JSON.stringify(request),
+      signal: AbortSignal.timeout(this.timeoutMs),
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `AgentShield returned HTTP ${response.status}: ${response.statusText}`,
+      );
+    }
+
+    const body = (await response.json()) as Record<string, unknown>;
+
+    if (typeof body.action !== "string" || !VALID_ACTIONS.has(body.action)) {
+      throw new Error(`AgentShield returned invalid action: ${String(body.action)}`);
+    }
+
+    return body as unknown as EvaluationResponse;
+  }
+
+  /** Fire-and-forget audit report after tool execution (Section 1.2). */
+  sendAudit(report: AuditReport): void {
+    this.fireAndForget(this.auditEndpoint, report, "audit");
+  }
+
+  /** Fire-and-forget lifecycle event (Section 1.3). */
+  sendLifecycle(event: LifecycleEvent): void {
+    this.fireAndForget(this.lifecycleEndpoint, event, "lifecycle");
+  }
+
+  /** Non-blocking startup probe; treats HTTP 2xx as reachable (Section 1.4). */
+  async healthCheck(): Promise<boolean> {
+    try {
+      const response = await fetch(this.healthEndpoint, {
+        method: "GET",
+        headers: this.buildHeaders(),
+        signal: AbortSignal.timeout(HEALTH_TIMEOUT_MS),
+      });
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Fire-and-forget feedback for an evaluation event (Section 1.6). */
+  submitFeedback(eventId: string, feedbackType: string, comment?: string): void {
+    const payload = {
+      event_id: eventId,
+      feedback_type: feedbackType,
+      comment: comment ?? null,
+      timestamp: new Date().toISOString(),
+    };
+    this.fireAndForget(this.feedbackEndpoint, payload, "feedback");
+  }
+
+  /** Fire-and-forget override report (Section 1.5). */
+  sendOverride(sessionId: string, eventId: string): void {
+    const payload: OverrideRequest = { session_id: sessionId, event_id: eventId };
+    this.fireAndForget(this.overrideEndpoint, payload, "override");
+  }
+
+  private fireAndForget(url: string, payload: unknown, label: string): void {
+    fetch(url, {
+      method: "POST",
+      headers: this.buildHeaders(),
+      body: JSON.stringify(payload),
+    }).catch((err: unknown) => {
+      this.logger.debug(`AgentShield ${label} send failed: ${String(err)}`);
+    });
+  }
+
+  private buildHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json; charset=utf-8",
+      "X-AgentShield-Version": CONTRACT_VERSION,
+    };
+    if (this.authToken) {
+      headers["Authorization"] = `Bearer ${this.authToken}`;
+    }
+    return headers;
+  }
+}

--- a/plugins/mcp-gateway/src/config.test.ts
+++ b/plugins/mcp-gateway/src/config.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+import { parseConfig } from "./config.js";
+
+const EMPTY_ENV = {} as NodeJS.ProcessEnv;
+
+describe("parseConfig", () => {
+  it("returns defaults when given undefined", () => {
+    const config = parseConfig(undefined, EMPTY_ENV);
+    expect(config.enabled).toBe(true);
+    expect(config.endpoint).toBe("http://127.0.0.1:8433/api/v1/evaluate");
+    expect(config.auth_token).toBe("");
+    expect(config.timeout_ms).toBe(200);
+    expect(config.timeout_policy).toBe("block");
+    expect(config.notify).toBe("high");
+    expect(config.circuit_breaker.failure_threshold).toBe(3);
+    expect(config.circuit_breaker.recovery_interval_ms).toBe(30_000);
+    expect(config.downstream.transport).toBe("stdio");
+    expect(config.serve.transport).toBe("stdio");
+  });
+
+  it("parses provided values", () => {
+    const config = parseConfig(
+      {
+        enabled: false,
+        endpoint: "http://localhost:9999/api/v1/evaluate",
+        auth_token: "secret123",
+        timeout_ms: 100,
+        timeout_policy: "log",
+        intercept: ["exec"],
+        skip: [],
+        notify: "all",
+        circuit_breaker: { failure_threshold: 5, recovery_interval_ms: 60_000 },
+        downstream: { transport: "http", url: "http://localhost:7000/mcp" },
+      },
+      EMPTY_ENV,
+    );
+    expect(config.enabled).toBe(false);
+    expect(config.endpoint).toBe("http://localhost:9999/api/v1/evaluate");
+    expect(config.auth_token).toBe("secret123");
+    expect(config.timeout_ms).toBe(100);
+    expect(config.timeout_policy).toBe("log");
+    expect(config.intercept).toEqual(["exec"]);
+    expect(config.skip).toEqual([]);
+    expect(config.circuit_breaker.failure_threshold).toBe(5);
+    expect(config.downstream.transport).toBe("http");
+    expect(config.downstream.url).toBe("http://localhost:7000/mcp");
+  });
+
+  it("falls back to AGENTSHIELD_AUTH_TOKEN env var when no token configured", () => {
+    const config = parseConfig({}, { AGENTSHIELD_AUTH_TOKEN: "env-token" } as NodeJS.ProcessEnv);
+    expect(config.auth_token).toBe("env-token");
+  });
+
+  it("prefers explicit config token over the env var", () => {
+    const config = parseConfig(
+      { auth_token: "cfg-token" },
+      { AGENTSHIELD_AUTH_TOKEN: "env-token" } as NodeJS.ProcessEnv,
+    );
+    expect(config.auth_token).toBe("cfg-token");
+  });
+
+  it("rejects invalid timeout_policy and uses default", () => {
+    expect(parseConfig({ timeout_policy: "invalid" }, EMPTY_ENV).timeout_policy).toBe("block");
+  });
+
+  it("clamps timeout_ms to the valid range", () => {
+    expect(parseConfig({ timeout_ms: 1 }, EMPTY_ENV).timeout_ms).toBe(200);
+    expect(parseConfig({ timeout_ms: 10_000 }, EMPTY_ENV).timeout_ms).toBe(200);
+    expect(parseConfig({ timeout_ms: 250 }, EMPTY_ENV).timeout_ms).toBe(250);
+  });
+
+  it("filters non-string entries from intercept and skip arrays", () => {
+    const config = parseConfig(
+      { intercept: ["exec", 42, "", null, "write"], skip: [true, "read"] },
+      EMPTY_ENV,
+    );
+    expect(config.intercept).toEqual(["exec", "write"]);
+    expect(config.skip).toEqual(["read"]);
+  });
+
+  it("uses default circuit breaker values for invalid input", () => {
+    const config = parseConfig(
+      { circuit_breaker: { failure_threshold: 0, recovery_interval_ms: 500 } },
+      EMPTY_ENV,
+    );
+    expect(config.circuit_breaker.failure_threshold).toBe(3);
+    expect(config.circuit_breaker.recovery_interval_ms).toBe(30_000);
+  });
+
+  it("honours environment overrides for endpoint and timeout", () => {
+    const config = parseConfig(
+      {},
+      {
+        AGENTSHIELD_ENDPOINT: "http://host:1234/api/v1/evaluate",
+        AGENTSHIELD_TIMEOUT_MS: "300",
+        AGENTSHIELD_TIMEOUT_POLICY: "allow",
+      } as NodeJS.ProcessEnv,
+    );
+    expect(config.endpoint).toBe("http://host:1234/api/v1/evaluate");
+    expect(config.timeout_ms).toBe(300);
+    expect(config.timeout_policy).toBe("allow");
+  });
+
+  it("reads downstream stdio command from env", () => {
+    const config = parseConfig(
+      {},
+      {
+        MCP_DOWNSTREAM_COMMAND: "npx",
+        MCP_DOWNSTREAM_ARGS: "-y @modelcontextprotocol/server-filesystem /data",
+      } as NodeJS.ProcessEnv,
+    );
+    expect(config.downstream.command).toBe("npx");
+    expect(config.downstream.args).toEqual([
+      "-y",
+      "@modelcontextprotocol/server-filesystem",
+      "/data",
+    ]);
+  });
+});

--- a/plugins/mcp-gateway/src/config.ts
+++ b/plugins/mcp-gateway/src/config.ts
@@ -1,0 +1,248 @@
+import { readFileSync } from "node:fs";
+
+import type { AgentShieldConfig, DownstreamTransport } from "./types.js";
+
+/**
+ * Default intercept list for the MCP gateway.
+ *
+ * Mirrors the canonical names plus the broad Hermes platform-name list, so the
+ * gateway intercepts dangerous tools regardless of which MCP server named them.
+ * Canonical names also match via the pipeline's intercept check (Section 3
+ * step 3), so a downstream `read_file` whose canonical form is `read` is caught
+ * by either `read_file` or `read`.
+ */
+const DEFAULT_INTERCEPT: string[] = [
+  // Canonical names
+  "exec",
+  "write",
+  "edit",
+  "read",
+  "browser",
+  "message",
+  "sessions_spawn",
+  "code_execute",
+  // Common MCP / platform names
+  "terminal",
+  "execute_command",
+  "run_command",
+  "shell",
+  "bash",
+  "write_file",
+  "create_file",
+  "edit_file",
+  "patch_file",
+  "read_file",
+  "web_browse",
+  "send_message",
+  "delegate",
+  "spawn_agent",
+  "python_execute",
+];
+
+const DEFAULT_SKIP: string[] = ["todo", "memory_search", "session_status"];
+
+const DEFAULTS: AgentShieldConfig = {
+  enabled: true,
+  endpoint: "http://127.0.0.1:8433/api/v1/evaluate",
+  auth_token: "",
+  timeout_ms: 200,
+  timeout_policy: "block",
+  intercept: DEFAULT_INTERCEPT,
+  skip: DEFAULT_SKIP,
+  notify: "high",
+  circuit_breaker: {
+    failure_threshold: 3,
+    recovery_interval_ms: 30_000,
+  },
+  downstream: {
+    transport: "stdio",
+    command: null,
+    args: [],
+    env: {},
+    url: null,
+  },
+  serve: {
+    transport: "stdio",
+    port: 8434,
+    host: "127.0.0.1",
+  },
+};
+
+const VALID_TIMEOUT_POLICIES = new Set(["allow", "block", "log"]);
+const VALID_NOTIFY_LEVELS = new Set(["all", "high", "critical", "none"]);
+const VALID_TRANSPORTS = new Set<DownstreamTransport>(["stdio", "http"]);
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  return value.filter((v): v is string => typeof v === "string" && v.trim().length > 0);
+}
+
+/**
+ * Parse and validate gateway configuration.
+ *
+ * Layering (lowest to highest precedence): defaults < JSON file < environment.
+ * `raw` is the parsed JSON config object; `env` is the process environment.
+ * All values are validated against the contract ranges (Section 4); invalid
+ * values fall back to defaults silently rather than throwing, matching the
+ * reference connectors.
+ */
+export function parseConfig(
+  raw: Record<string, unknown> | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): AgentShieldConfig {
+  const cfg = raw && typeof raw === "object" ? raw : {};
+
+  const enabled =
+    typeof cfg.enabled === "boolean"
+      ? cfg.enabled
+      : env.AGENTSHIELD_ENABLED === "false"
+        ? false
+        : DEFAULTS.enabled;
+
+  const endpoint =
+    asString(env.AGENTSHIELD_ENDPOINT) ?? asString(cfg.endpoint) ?? DEFAULTS.endpoint;
+
+  // Auth token: explicit config > env var > empty (contract Section 4).
+  const cfgToken = typeof cfg.auth_token === "string" ? cfg.auth_token : "";
+  const auth_token = cfgToken || env.AGENTSHIELD_AUTH_TOKEN || DEFAULTS.auth_token;
+
+  const rawTimeout =
+    env.AGENTSHIELD_TIMEOUT_MS !== undefined
+      ? Number(env.AGENTSHIELD_TIMEOUT_MS)
+      : cfg.timeout_ms;
+  const timeout_ms =
+    typeof rawTimeout === "number" &&
+    Number.isFinite(rawTimeout) &&
+    rawTimeout >= 5 &&
+    rawTimeout <= 5000
+      ? Math.round(rawTimeout)
+      : DEFAULTS.timeout_ms;
+
+  const rawPolicy = asString(env.AGENTSHIELD_TIMEOUT_POLICY) ?? cfg.timeout_policy;
+  const timeout_policy =
+    typeof rawPolicy === "string" && VALID_TIMEOUT_POLICIES.has(rawPolicy)
+      ? (rawPolicy as AgentShieldConfig["timeout_policy"])
+      : DEFAULTS.timeout_policy;
+
+  const rawNotify = asString(env.AGENTSHIELD_NOTIFY) ?? cfg.notify;
+  const notify =
+    typeof rawNotify === "string" && VALID_NOTIFY_LEVELS.has(rawNotify)
+      ? (rawNotify as AgentShieldConfig["notify"])
+      : DEFAULTS.notify;
+
+  const intercept = asStringArray(cfg.intercept) ?? DEFAULTS.intercept;
+  const skip = asStringArray(cfg.skip) ?? DEFAULTS.skip;
+
+  const rawCb =
+    cfg.circuit_breaker && typeof cfg.circuit_breaker === "object" && !Array.isArray(cfg.circuit_breaker)
+      ? (cfg.circuit_breaker as Record<string, unknown>)
+      : {};
+
+  const circuit_breaker = {
+    failure_threshold:
+      typeof rawCb.failure_threshold === "number" && rawCb.failure_threshold >= 1
+        ? Math.round(rawCb.failure_threshold)
+        : DEFAULTS.circuit_breaker.failure_threshold,
+    recovery_interval_ms:
+      typeof rawCb.recovery_interval_ms === "number" && rawCb.recovery_interval_ms >= 1000
+        ? Math.round(rawCb.recovery_interval_ms)
+        : DEFAULTS.circuit_breaker.recovery_interval_ms,
+  };
+
+  const downstream = parseDownstream(cfg.downstream, env);
+  const serve = parseServe(cfg.serve, env);
+
+  return {
+    enabled,
+    endpoint,
+    auth_token,
+    timeout_ms,
+    timeout_policy,
+    intercept,
+    skip,
+    notify,
+    circuit_breaker,
+    downstream,
+    serve,
+  };
+}
+
+function parseDownstream(
+  raw: unknown,
+  env: NodeJS.ProcessEnv,
+): AgentShieldConfig["downstream"] {
+  const d = raw && typeof raw === "object" && !Array.isArray(raw) ? (raw as Record<string, unknown>) : {};
+
+  const rawTransport = asString(env.MCP_DOWNSTREAM_TRANSPORT) ?? d.transport;
+  const transport =
+    typeof rawTransport === "string" && VALID_TRANSPORTS.has(rawTransport as DownstreamTransport)
+      ? (rawTransport as DownstreamTransport)
+      : DEFAULTS.downstream.transport;
+
+  // Command may be supplied as a single env string ("node server.js --flag");
+  // we keep it as the bare command and rely on args for the rest.
+  const command = asString(env.MCP_DOWNSTREAM_COMMAND) ?? asString(d.command) ?? null;
+
+  let args: string[] = DEFAULTS.downstream.args;
+  if (env.MCP_DOWNSTREAM_ARGS) {
+    args = env.MCP_DOWNSTREAM_ARGS.split(" ").filter((a) => a.length > 0);
+  } else {
+    args = asStringArray(d.args) ?? DEFAULTS.downstream.args;
+  }
+
+  let envVars: Record<string, string> = {};
+  if (d.env && typeof d.env === "object" && !Array.isArray(d.env)) {
+    for (const [k, v] of Object.entries(d.env as Record<string, unknown>)) {
+      if (typeof v === "string") {
+        envVars[k] = v;
+      }
+    }
+  }
+
+  const url = asString(env.MCP_DOWNSTREAM_URL) ?? asString(d.url) ?? null;
+
+  return { transport, command, args, env: envVars, url };
+}
+
+function parseServe(raw: unknown, env: NodeJS.ProcessEnv): AgentShieldConfig["serve"] {
+  const s = raw && typeof raw === "object" && !Array.isArray(raw) ? (raw as Record<string, unknown>) : {};
+
+  const rawTransport = asString(env.MCP_SERVE_TRANSPORT) ?? s.transport;
+  const transport =
+    typeof rawTransport === "string" && VALID_TRANSPORTS.has(rawTransport as DownstreamTransport)
+      ? (rawTransport as DownstreamTransport)
+      : DEFAULTS.serve.transport;
+
+  const rawPort = env.MCP_SERVE_PORT !== undefined ? Number(env.MCP_SERVE_PORT) : s.port;
+  const port =
+    typeof rawPort === "number" && Number.isFinite(rawPort) && rawPort > 0 && rawPort <= 65535
+      ? Math.round(rawPort)
+      : DEFAULTS.serve.port;
+
+  const host = asString(env.MCP_SERVE_HOST) ?? asString(s.host) ?? DEFAULTS.serve.host;
+
+  return { transport, port, host };
+}
+
+/** Load a JSON config file from disk, returning undefined if absent or invalid. */
+export function loadConfigFile(path: string | undefined): Record<string, unknown> | undefined {
+  if (!path) {
+    return undefined;
+  }
+  try {
+    const text = readFileSync(path, "utf8");
+    const parsed = JSON.parse(text) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/plugins/mcp-gateway/src/event-builder.test.ts
+++ b/plugins/mcp-gateway/src/event-builder.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildAuditReport,
+  buildEvaluationRequest,
+  buildLifecycleEvent,
+  summariseResult,
+} from "./event-builder.js";
+
+const CTX = { agentId: "agent-1", sessionId: "sess-1" };
+
+describe("buildEvaluationRequest", () => {
+  it("builds a canonical envelope with source mcp-gateway", () => {
+    const req = buildEvaluationRequest(
+      { toolName: "mcp__shell__execute_command", params: { command: "rm -rf /" } },
+      CTX,
+    );
+    expect(req.source).toBe("mcp-gateway");
+    expect(req.tool_name).toBe("exec");
+    expect(req.event_type).toBe("tool_call");
+    expect(req.command).toBe("rm -rf /");
+    expect(req.params.command).toBe("rm -rf /");
+    expect(req.params._mcp_original_tool).toBe("mcp__shell__execute_command");
+    expect(req.agent_id).toBe("agent-1");
+    expect(req.session_id).toBe("sess-1");
+    expect(req.event_id).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it("uses file_write event type for write tools", () => {
+    const req = buildEvaluationRequest(
+      { toolName: "write_file", params: { path: "/tmp/x" } },
+      CTX,
+    );
+    expect(req.tool_name).toBe("write");
+    expect(req.event_type).toBe("file_write");
+    expect(req.command).toBe("Write: /tmp/x");
+  });
+});
+
+describe("buildAuditReport", () => {
+  it("builds a tool_result report with correlation id", () => {
+    const report = buildAuditReport(
+      { toolName: "read_file", params: { path: "/x" }, result: "contents", durationMs: 12 },
+      CTX,
+      "corr-123",
+    );
+    expect(report.event_type).toBe("tool_result");
+    expect(report.source).toBe("mcp-gateway");
+    expect(report.tool_name).toBe("read");
+    expect(report.correlation_id).toBe("corr-123");
+    expect(report.result_summary).toBe("contents");
+    expect(report.is_error).toBe(false);
+    expect(report.duration_ms).toBe(12);
+  });
+
+  it("flags errors", () => {
+    const report = buildAuditReport(
+      { toolName: "exec", params: {}, error: "boom", isError: true },
+      CTX,
+      "c",
+    );
+    expect(report.is_error).toBe(true);
+    expect(report.error_message).toBe("boom");
+  });
+});
+
+describe("buildLifecycleEvent", () => {
+  it("builds session_start", () => {
+    const ev = buildLifecycleEvent("session_start", CTX);
+    expect(ev.event_type).toBe("session_start");
+    expect(ev.source).toBe("mcp-gateway");
+    expect(ev.session_id).toBe("sess-1");
+  });
+});
+
+describe("summariseResult", () => {
+  it("returns null for nullish", () => {
+    expect(summariseResult(null)).toBeNull();
+    expect(summariseResult(undefined)).toBeNull();
+  });
+
+  it("truncates to 1000 chars", () => {
+    const out = summariseResult("a".repeat(1500));
+    expect(out).toHaveLength(1000);
+  });
+
+  it("stringifies objects", () => {
+    expect(summariseResult({ a: 1 })).toBe('{"a":1}');
+  });
+});

--- a/plugins/mcp-gateway/src/event-builder.ts
+++ b/plugins/mcp-gateway/src/event-builder.ts
@@ -1,0 +1,123 @@
+import { randomUUID } from "node:crypto";
+
+import { eventTypeForToolCall, normaliseToolCall } from "./normalise.js";
+import type { AuditReport, EvaluationRequest, LifecycleEvent } from "./types.js";
+
+const MAX_RESULT_SUMMARY_LENGTH = 1000;
+
+const SOURCE = "mcp-gateway" as const;
+
+export type ToolCallEvent = {
+  toolName: string;
+  params: Record<string, unknown>;
+};
+
+export type ToolContext = {
+  agentId: string | null;
+  sessionId: string | null;
+};
+
+export type ToolResultEvent = ToolCallEvent & {
+  result?: unknown;
+  error?: string;
+  isError?: boolean;
+  durationMs?: number;
+};
+
+/** Build an EvaluationRequest envelope (contract Section 1.1). */
+export function buildEvaluationRequest(
+  event: ToolCallEvent,
+  ctx: ToolContext,
+): EvaluationRequest {
+  const { canonical, command } = normaliseToolCall(event.toolName, event.params);
+  const eventType = eventTypeForToolCall(canonical);
+
+  return {
+    event_id: randomUUID(),
+    timestamp: new Date().toISOString(),
+    event_type: eventType,
+    // Send the canonical name so the engine maps it to action.name and the same
+    // Sigma rules match across connectors. The original name is preserved in
+    // params for downstream debugging.
+    tool_name: canonical,
+    source: SOURCE,
+    command,
+    params: {
+      ...event.params,
+      ...(event.toolName !== canonical ? { _mcp_original_tool: event.toolName } : {}),
+      // Duplicate command into params so the engine auto-maps it to
+      // process.command_line (Section 1.1, Section 2.2).
+      ...(command ? { command } : {}),
+    },
+    agent_id: ctx.agentId,
+    session_id: ctx.sessionId,
+    working_dir: null,
+    data: {},
+  };
+}
+
+/** Build an AuditReport (contract Section 1.2). */
+export function buildAuditReport(
+  event: ToolResultEvent,
+  ctx: ToolContext,
+  correlationId: string,
+): AuditReport {
+  const { canonical } = normaliseToolCall(event.toolName, event.params);
+  const isError = event.isError ?? event.error !== undefined;
+
+  return {
+    event_id: randomUUID(),
+    correlation_id: correlationId,
+    timestamp: new Date().toISOString(),
+    event_type: "tool_result",
+    tool_name: canonical,
+    source: SOURCE,
+    result_summary: summariseResult(event.result),
+    is_error: isError,
+    error_message: event.error ?? null,
+    duration_ms: event.durationMs ?? 0,
+    agent_id: ctx.agentId,
+    session_id: ctx.sessionId,
+    working_dir: null,
+    data: {},
+  };
+}
+
+/** Build a LifecycleEvent (contract Section 1.3). */
+export function buildLifecycleEvent(
+  eventType: "session_start" | "session_end",
+  ctx: ToolContext,
+  data: Record<string, unknown> = {},
+): LifecycleEvent {
+  return {
+    event_id: randomUUID(),
+    timestamp: new Date().toISOString(),
+    event_type: eventType,
+    source: SOURCE,
+    agent_id: ctx.agentId,
+    session_id: ctx.sessionId,
+    data,
+  };
+}
+
+/** Summarise a tool result to at most MAX_RESULT_SUMMARY_LENGTH chars. */
+export function summariseResult(result: unknown): string | null {
+  if (result === undefined || result === null) {
+    return null;
+  }
+
+  let text: string;
+  if (typeof result === "string") {
+    text = result;
+  } else {
+    try {
+      text = JSON.stringify(result);
+    } catch {
+      text = String(result);
+    }
+  }
+
+  return text.length > MAX_RESULT_SUMMARY_LENGTH
+    ? text.slice(0, MAX_RESULT_SUMMARY_LENGTH)
+    : text;
+}

--- a/plugins/mcp-gateway/src/gateway.ts
+++ b/plugins/mcp-gateway/src/gateway.ts
@@ -1,0 +1,225 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import {
+  CallToolRequestSchema,
+  CallToolResultSchema,
+  ListToolsRequestSchema,
+  type ServerCapabilities,
+} from "@modelcontextprotocol/sdk/types.js";
+
+import { AgentShieldClient } from "./client.js";
+import { GatewayPipeline } from "./pipeline.js";
+import type { AgentShieldConfig, Logger } from "./types.js";
+
+const GATEWAY_VERSION = "1.0.0";
+
+/**
+ * Build the downstream MCP client transport from configuration.
+ *
+ * stdio launches a child process; http connects to a Streamable HTTP endpoint.
+ * The child process environment is the gateway's own environment merged with
+ * any explicit overrides — we never silently leak unexpected variables beyond
+ * the inherited set the SDK already filters.
+ */
+function buildDownstreamTransport(config: AgentShieldConfig, logger: Logger): Transport {
+  const d = config.downstream;
+  if (d.transport === "http") {
+    if (!d.url) {
+      throw new Error("downstream.transport is 'http' but no downstream.url was configured");
+    }
+    logger.info(`Connecting to downstream MCP server over HTTP: ${d.url}`);
+    return new StreamableHTTPClientTransport(new URL(d.url));
+  }
+
+  if (!d.command) {
+    throw new Error("downstream.transport is 'stdio' but no downstream.command was configured");
+  }
+  logger.info(`Launching downstream MCP server: ${d.command} ${d.args.join(" ")}`.trim());
+  return new StdioClientTransport({
+    command: d.command,
+    args: d.args,
+    env: { ...(process.env as Record<string, string>), ...d.env },
+    stderr: "inherit",
+  });
+}
+
+/**
+ * AgentShield MCP security gateway.
+ *
+ * A transparent proxy: it exposes an MCP {@link Server} to the upstream agent
+ * and holds a {@link Client} to one downstream MCP server. `tools/list` is
+ * forwarded verbatim; `tools/call` is evaluated by the {@link GatewayPipeline}
+ * and either blocked (returned as an isError tool result carrying the block
+ * reason) or forwarded. `initialize`/shutdown are mapped to lifecycle events.
+ */
+export class McpGateway {
+  private readonly config: AgentShieldConfig;
+  private readonly logger: Logger;
+  private readonly pipeline: GatewayPipeline;
+  private readonly downstream: Client;
+  private server: Server | null = null;
+  private sessionId: string | null = null;
+  private agentId: string | null = null;
+  private lifecycleStarted = false;
+
+  constructor(config: AgentShieldConfig, logger: Logger) {
+    this.config = config;
+    this.logger = logger;
+    const httpClient = new AgentShieldClient(config, logger);
+    this.pipeline = new GatewayPipeline(config, httpClient, logger);
+    this.downstream = new Client(
+      { name: "agentshield-mcp-gateway", version: GATEWAY_VERSION },
+      { capabilities: {} },
+    );
+  }
+
+  /**
+   * Connect to the downstream server, mirror its identity/capabilities onto the
+   * upstream-facing server, wire request handlers, and run the startup health
+   * check (non-blocking).
+   */
+  async start(upstreamTransport: Transport): Promise<void> {
+    const downstreamTransport = buildDownstreamTransport(this.config, this.logger);
+    await this.downstream.connect(downstreamTransport);
+
+    const downstreamInfo = this.downstream.getServerVersion();
+    const downstreamCaps = this.downstream.getServerCapabilities() ?? {};
+    const instructions = this.downstream.getInstructions();
+
+    this.server = new Server(
+      {
+        name: downstreamInfo?.name ?? "agentshield-mcp-gateway",
+        version: downstreamInfo?.version ?? GATEWAY_VERSION,
+      },
+      {
+        // Advertise exactly what the downstream advertises so the agent sees a
+        // faithful passthrough; we only intervene on tools/call.
+        capabilities: downstreamCaps as ServerCapabilities,
+        ...(instructions ? { instructions } : {}),
+      },
+    );
+
+    this.registerHandlers(this.server);
+
+    // Map MCP initialize -> lifecycle session_start (contract Section 1.3).
+    this.server.oninitialized = () => {
+      const clientInfo = this.server?.getClientVersion();
+      this.agentId = clientInfo?.name ?? null;
+      this.sessionId = `mcp-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+      this.lifecycleStarted = true;
+      this.pipeline.recordLifecycle("session_start", this.ctx());
+      this.logger.info(
+        `MCP session started (agent=${this.agentId ?? "unknown"}, session=${this.sessionId})`,
+      );
+    };
+
+    // Map transport close (shutdown) -> lifecycle session_end.
+    this.server.onclose = () => {
+      void this.emitSessionEnd();
+    };
+
+    await this.server.connect(upstreamTransport);
+
+    // Step 10: non-blocking startup health check.
+    void this.pipeline.startupHealthCheck();
+  }
+
+  /** Disconnect from both transports and emit session_end if needed. */
+  async stop(): Promise<void> {
+    await this.emitSessionEnd();
+    try {
+      await this.server?.close();
+    } catch (err: unknown) {
+      this.logger.debug(`Error closing upstream server: ${String(err)}`);
+    }
+    try {
+      await this.downstream.close();
+    } catch (err: unknown) {
+      this.logger.debug(`Error closing downstream client: ${String(err)}`);
+    }
+  }
+
+  private async emitSessionEnd(): Promise<void> {
+    if (this.lifecycleStarted) {
+      this.lifecycleStarted = false;
+      this.pipeline.recordLifecycle("session_end", this.ctx());
+    }
+  }
+
+  private ctx(): { agentId: string | null; sessionId: string | null } {
+    return { agentId: this.agentId, sessionId: this.sessionId };
+  }
+
+  private registerHandlers(server: Server): void {
+    // tools/list -> transparent passthrough (contract: list passes through).
+    server.setRequestHandler(ListToolsRequestSchema, async (request) => {
+      return this.downstream.listTools(request.params);
+    });
+
+    // tools/call -> evaluate, then block or forward.
+    server.setRequestHandler(CallToolRequestSchema, async (request) => {
+      const toolName = request.params.name;
+      const args = (request.params.arguments ?? {}) as Record<string, unknown>;
+
+      const decision = await this.pipeline.evaluateToolCall(toolName, args, this.ctx());
+
+      if (!decision.allowed) {
+        // Return a tool result with isError=true so the agent receives the
+        // block reason in-band rather than a protocol error it might retry.
+        const prefix = decision.overridable
+          ? "AgentShield requires approval"
+          : "AgentShield blocked this tool call";
+        this.logger.warn(`Denied ${toolName}: ${decision.reason ?? prefix}`);
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `${prefix}: ${decision.reason ?? "policy violation"}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      // Forward to the downstream server and time it for the audit report.
+      const startedAt = Date.now();
+      try {
+        const result = await this.downstream.callTool(request.params, CallToolResultSchema);
+        const durationMs = Date.now() - startedAt;
+        const isError = result.isError === true;
+        this.pipeline.recordResult(toolName, args, this.ctx(), result.content, {
+          isError,
+          errorMessage: isError ? this.extractText(result.content) : null,
+          durationMs,
+        });
+        return result;
+      } catch (err: unknown) {
+        const durationMs = Date.now() - startedAt;
+        const message = err instanceof Error ? err.message : String(err);
+        this.pipeline.recordResult(toolName, args, this.ctx(), null, {
+          isError: true,
+          errorMessage: message,
+          durationMs,
+        });
+        // Surface the downstream error to the agent unchanged.
+        throw err;
+      }
+    });
+  }
+
+  private extractText(content: unknown): string | null {
+    if (!Array.isArray(content)) {
+      return null;
+    }
+    const texts = content
+      .filter(
+        (c): c is { type: string; text: string } =>
+          typeof c === "object" && c !== null && (c as { type?: string }).type === "text",
+      )
+      .map((c) => c.text);
+    return texts.length > 0 ? texts.join("\n") : null;
+  }
+}

--- a/plugins/mcp-gateway/src/index.ts
+++ b/plugins/mcp-gateway/src/index.ts
@@ -1,0 +1,43 @@
+import type { Logger } from "./types.js";
+
+export { parseConfig, loadConfigFile } from "./config.js";
+export { CircuitBreaker } from "./circuit-breaker.js";
+export { AgentShieldClient } from "./client.js";
+export {
+  normaliseToolCall,
+  normaliseToolName,
+  eventTypeForToolCall,
+  stripNamespace,
+} from "./normalise.js";
+export {
+  buildEvaluationRequest,
+  buildAuditReport,
+  buildLifecycleEvent,
+  summariseResult,
+} from "./event-builder.js";
+export { GatewayPipeline, type Decision } from "./pipeline.js";
+export { McpGateway } from "./gateway.js";
+export type * from "./types.js";
+
+/**
+ * Build a stderr-only logger.
+ *
+ * stdout must stay reserved for the MCP stdio framing, so every diagnostic is
+ * written to stderr. The level gates debug output. Logger name is "agentshield"
+ * to match the reference connectors (contract Section 6).
+ */
+export function createLogger(level: "debug" | "info" | "warn" | "error" = "info"): Logger {
+  const order: Record<string, number> = { debug: 0, info: 1, warn: 2, error: 3 };
+  const threshold = order[level] ?? 1;
+  const emit = (lvl: keyof typeof order, message: string): void => {
+    if ((order[lvl] ?? 1) >= threshold) {
+      process.stderr.write(`[agentshield] ${lvl.toUpperCase()} ${message}\n`);
+    }
+  };
+  return {
+    debug: (m) => emit("debug", m),
+    info: (m) => emit("info", m),
+    warn: (m) => emit("warn", m),
+    error: (m) => emit("error", m),
+  };
+}

--- a/plugins/mcp-gateway/src/normalise.test.ts
+++ b/plugins/mcp-gateway/src/normalise.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  eventTypeForToolCall,
+  normaliseToolCall,
+  normaliseToolName,
+  stripNamespace,
+} from "./normalise.js";
+
+describe("stripNamespace", () => {
+  it("strips mcp__server__tool prefixes", () => {
+    expect(stripNamespace("mcp__filesystem__read_file")).toBe("read_file");
+  });
+
+  it("strips dotted namespaces", () => {
+    expect(stripNamespace("filesystem.read_file")).toBe("read_file");
+  });
+
+  it("strips slash and colon namespaces", () => {
+    expect(stripNamespace("git/commit")).toBe("commit");
+    expect(stripNamespace("server:exec")).toBe("exec");
+  });
+
+  it("leaves bare names unchanged", () => {
+    expect(stripNamespace("read_file")).toBe("read_file");
+  });
+});
+
+describe("normaliseToolName", () => {
+  it("maps platform aliases to canonical names", () => {
+    expect(normaliseToolName("execute_command")).toBe("exec");
+    expect(normaliseToolName("write_file")).toBe("write");
+    expect(normaliseToolName("delegate")).toBe("sessions_spawn");
+  });
+
+  it("maps namespaced MCP tools after stripping the prefix", () => {
+    expect(normaliseToolName("mcp__shell__run_command")).toBe("exec");
+    expect(normaliseToolName("fs.read_file")).toBe("read");
+  });
+
+  it("passes unknown tools through unchanged", () => {
+    expect(normaliseToolName("custom_tool")).toBe("custom_tool");
+  });
+});
+
+describe("normaliseToolCall", () => {
+  it("maps exec with command", () => {
+    const result = normaliseToolCall("execute_command", { command: "ls -la" });
+    expect(result.canonical).toBe("exec");
+    expect(result.command).toBe("ls -la");
+  });
+
+  it("maps exec with missing command to null", () => {
+    expect(normaliseToolCall("shell", {}).command).toBeNull();
+  });
+
+  it("maps write with path", () => {
+    expect(normaliseToolCall("write_file", { path: "/tmp/foo.txt" }).command).toBe(
+      "Write: /tmp/foo.txt",
+    );
+  });
+
+  it("maps read with file_path fallback", () => {
+    expect(normaliseToolCall("read_file", { file_path: "/etc/passwd" }).command).toBe(
+      "Read: /etc/passwd",
+    );
+  });
+
+  it("maps edit with path", () => {
+    expect(normaliseToolCall("edit_file", { path: "/src/main.ts" }).command).toBe(
+      "Edit: /src/main.ts",
+    );
+  });
+
+  it("maps browser with action and url", () => {
+    expect(
+      normaliseToolCall("browser", { action: "navigate", url: "https://example.com" }).command,
+    ).toBe("navigate: https://example.com");
+  });
+
+  it("defaults browser action to navigate", () => {
+    expect(normaliseToolCall("web_browse", { url: "https://x.test" }).command).toBe(
+      "navigate: https://x.test",
+    );
+  });
+
+  it("maps message with channel", () => {
+    expect(normaliseToolCall("send_message", { channel: "telegram" }).command).toBe(
+      "Message to telegram",
+    );
+  });
+
+  it("maps message without channel to platform form", () => {
+    expect(normaliseToolCall("slack_send", {}).command).toBe("Message via slack");
+  });
+
+  it("maps sessions_spawn with agent_id", () => {
+    expect(normaliseToolCall("spawn_agent", { agent_id: "agent-42" }).command).toBe(
+      "Spawn: agent-42",
+    );
+  });
+
+  it("maps sessions_spawn without agent to unknown", () => {
+    expect(normaliseToolCall("delegate", {}).command).toBe("Spawn: <unknown>");
+  });
+
+  it("truncates code_execute commands to 200 chars", () => {
+    const long = "x".repeat(250);
+    const result = normaliseToolCall("python_execute", { code: long });
+    expect(result.command).toBe(`Execute: ${"x".repeat(200)}...`);
+  });
+
+  it("maps web_search query", () => {
+    expect(normaliseToolCall("search", { query: "exfil" }).command).toBe("Search: exfil");
+  });
+
+  it("falls back to the original tool name for unknown tools", () => {
+    expect(normaliseToolCall("custom_tool", { foo: "bar" }).command).toBe("custom_tool");
+  });
+
+  it("handles file ops with no path", () => {
+    expect(normaliseToolCall("write_file", {}).command).toBe("Write: <unknown>");
+  });
+});
+
+describe("eventTypeForToolCall", () => {
+  it("maps read to file_read", () => {
+    expect(eventTypeForToolCall("read")).toBe("file_read");
+  });
+
+  it("maps write to file_write", () => {
+    expect(eventTypeForToolCall("write")).toBe("file_write");
+  });
+
+  it("maps edit to file_edit", () => {
+    expect(eventTypeForToolCall("edit")).toBe("file_edit");
+  });
+
+  it("maps sessions_spawn to session_spawn", () => {
+    expect(eventTypeForToolCall("sessions_spawn")).toBe("session_spawn");
+  });
+
+  it("defaults to tool_call", () => {
+    expect(eventTypeForToolCall("exec")).toBe("tool_call");
+  });
+});

--- a/plugins/mcp-gateway/src/normalise.ts
+++ b/plugins/mcp-gateway/src/normalise.ts
@@ -1,0 +1,213 @@
+/**
+ * Map MCP tool names and arguments to AgentShield canonical forms.
+ *
+ * MCP servers expose arbitrary tool names. Clients frequently namespace them
+ * (e.g. `mcp__filesystem__read_file`, `filesystem.read_file`,
+ * `filesystem/read_file`). We first strip any namespace prefix, then apply the
+ * canonical alias table (mirroring `plugins/hermes/normalise.py` — the broadest
+ * reference, contract Section 2.1) so the same Sigma rules match regardless of
+ * which MCP server emitted the call. Unknown tools pass through unchanged.
+ */
+
+/** MCP / platform tool name -> AgentShield canonical name (contract Section 2.1). */
+const TOOL_ALIASES: Record<string, string> = {
+  // Terminal / exec
+  terminal: "exec",
+  execute_command: "exec",
+  run_command: "exec",
+  shell: "exec",
+  bash: "exec",
+  Bash: "exec",
+  computer: "exec",
+  // File write
+  write_file: "write",
+  create_file: "write",
+  save_file: "write",
+  Write: "write",
+  create: "write",
+  // File read
+  read_file: "read",
+  view_file: "read",
+  Read: "read",
+  cat: "read",
+  file_read: "read",
+  // File edit
+  edit_file: "edit",
+  patch_file: "edit",
+  replace_in_file: "edit",
+  Edit: "edit",
+  str_replace_editor: "edit",
+  // Browser
+  web_browse: "browser",
+  browser: "browser",
+  navigate: "browser",
+  browse_url: "browser",
+  web_browser: "browser",
+  // Messaging
+  send_message: "message",
+  telegram_send: "message",
+  discord_send: "message",
+  slack_send: "message",
+  whatsapp_send: "message",
+  signal_send: "message",
+  // Agent delegation
+  delegate: "sessions_spawn",
+  spawn_agent: "sessions_spawn",
+  create_subagent: "sessions_spawn",
+  Agent: "sessions_spawn",
+  // Code execution
+  code_execute: "code_execute",
+  python_execute: "code_execute",
+  run_python: "code_execute",
+  // Web search
+  web_search: "web_search",
+  search: "web_search",
+  // Image generation
+  image_generate: "image_generate",
+  generate_image: "image_generate",
+  // Vision
+  vision: "vision",
+  analyze_image: "vision",
+  // TTS
+  text_to_speech: "tts",
+  tts: "tts",
+  // Memory
+  memory_add: "memory",
+  memory_search: "memory",
+  memory_delete: "memory",
+  // Task planning
+  task_plan: "planning",
+  todo: "planning",
+  // Cron
+  cron_add: "cron",
+  cron_remove: "cron",
+  cron_list: "cron",
+};
+
+/**
+ * Strip a common MCP namespace prefix from a tool name.
+ *
+ * Handles `mcp__server__tool`, `server.tool`, `server/tool`, and `server:tool`.
+ * The bare tool segment is returned for alias lookup; the original is preserved
+ * by the caller for the `tool_name` wire field.
+ */
+export function stripNamespace(toolName: string): string {
+  if (toolName.includes("__")) {
+    // `mcp__<server>__<tool>` or `<server>__<tool>` -> last segment.
+    const parts = toolName.split("__").filter((p) => p.length > 0);
+    return parts.length > 0 ? (parts[parts.length - 1] as string) : toolName;
+  }
+  for (const sep of [".", "/", ":"]) {
+    if (toolName.includes(sep)) {
+      const parts = toolName.split(sep).filter((p) => p.length > 0);
+      return parts.length > 0 ? (parts[parts.length - 1] as string) : toolName;
+    }
+  }
+  return toolName;
+}
+
+/** Return the AgentShield canonical name for an MCP tool (unknown -> unchanged). */
+export function normaliseToolName(toolName: string): string {
+  const bare = stripNamespace(toolName);
+  return TOOL_ALIASES[bare] ?? bare;
+}
+
+/**
+ * Normalise an MCP tool call into its canonical name and a human-readable
+ * command string used by the engine for Sigma field matching (Section 2.2).
+ */
+export function normaliseToolCall(
+  toolName: string,
+  args: Record<string, unknown>,
+): { canonical: string; command: string | null } {
+  const canonical = normaliseToolName(toolName);
+  const command = buildCommand(canonical, toolName, args);
+  return { canonical, command };
+}
+
+/** Return the semantic event type for a normalised tool call (Section 2.3). */
+export function eventTypeForToolCall(canonical: string): string {
+  switch (canonical) {
+    case "read":
+    case "file_read":
+      return "file_read";
+    case "write":
+    case "file_write":
+    case "create":
+      return "file_write";
+    case "edit":
+    case "file_edit":
+      return "file_edit";
+    case "sessions_spawn":
+    case "session_spawn":
+      return "session_spawn";
+    default:
+      return "tool_call";
+  }
+}
+
+/** Build the per-canonical-name command string (contract Section 2.2). */
+function buildCommand(
+  canonical: string,
+  original: string,
+  args: Record<string, unknown>,
+): string | null {
+  switch (canonical) {
+    case "exec": {
+      const cmd = args.command ?? args.cmd;
+      return typeof cmd === "string" && cmd ? cmd : null;
+    }
+    case "write":
+      return `Write: ${filePath(args)}`;
+    case "read":
+      return `Read: ${filePath(args)}`;
+    case "edit":
+      return `Edit: ${filePath(args)}`;
+    case "browser": {
+      const action = str(args.action) || "navigate";
+      const url = str(args.url);
+      return `${action}: ${url}`.trim();
+    }
+    case "message": {
+      const channel = str(args.channel) || str(args.chat_id) || str(args.to);
+      if (channel) {
+        return `Message to ${channel}`;
+      }
+      const platform = original.replace("_send", "").replace("send_", "");
+      return `Message via ${platform}`;
+    }
+    case "sessions_spawn": {
+      const agent =
+        str(args.agent_id) || str(args.agent) || str(args.task) || str(args.agentId);
+      return agent ? `Spawn: ${agent}` : "Spawn: <unknown>";
+    }
+    case "code_execute": {
+      let code = str(args.code) || str(args.script);
+      if (code.length > 200) {
+        code = `${code.slice(0, 200)}...`;
+      }
+      return code ? `Execute: ${code}` : null;
+    }
+    case "web_search": {
+      const query = str(args.query) || str(args.q);
+      return query ? `Search: ${query}` : null;
+    }
+    default:
+      return original;
+  }
+}
+
+/** Extract a file path from the various argument styles MCP servers use. */
+function filePath(args: Record<string, unknown>): string {
+  for (const key of ["path", "file_path", "filepath", "filename", "file"]) {
+    const val = args[key];
+    if (typeof val === "string" && val) {
+      return val;
+    }
+  }
+  return "<unknown>";
+}
+
+function str(value: unknown): string {
+  return value === null || value === undefined ? "" : String(value);
+}

--- a/plugins/mcp-gateway/src/pipeline.test.ts
+++ b/plugins/mcp-gateway/src/pipeline.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { AgentShieldClient } from "./client.js";
+import { GatewayPipeline } from "./pipeline.js";
+import type { AgentShieldConfig, EvaluationResponse, Logger } from "./types.js";
+
+const SILENT_LOGGER: Logger = {
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+};
+
+const CTX = { agentId: "a", sessionId: "s" };
+
+function baseConfig(overrides: Partial<AgentShieldConfig> = {}): AgentShieldConfig {
+  return {
+    enabled: true,
+    endpoint: "http://127.0.0.1:8433/api/v1/evaluate",
+    auth_token: "",
+    timeout_ms: 200,
+    timeout_policy: "block",
+    intercept: [],
+    skip: ["todo"],
+    notify: "high",
+    circuit_breaker: { failure_threshold: 1, recovery_interval_ms: 30_000 },
+    downstream: { transport: "stdio", command: "x", args: [], env: {}, url: null },
+    serve: { transport: "stdio", port: 8434, host: "127.0.0.1" },
+    ...overrides,
+  };
+}
+
+/** Build a pipeline with a stubbed client returning the given evaluate result. */
+function makePipeline(
+  evaluate: () => Promise<EvaluationResponse> | EvaluationResponse,
+  config: AgentShieldConfig = baseConfig(),
+): { pipeline: GatewayPipeline; sendAudit: ReturnType<typeof vi.fn> } {
+  const sendAudit = vi.fn();
+  const client = {
+    evaluate: vi.fn(async () => evaluate()),
+    sendAudit,
+    sendLifecycle: vi.fn(),
+    healthCheck: vi.fn(async () => true),
+    submitFeedback: vi.fn(),
+    sendOverride: vi.fn(),
+  } as unknown as AgentShieldClient;
+  return { pipeline: new GatewayPipeline(config, client, SILENT_LOGGER), sendAudit };
+}
+
+const ALLOW: EvaluationResponse = { action: "allow", event_id: "e" };
+
+describe("GatewayPipeline.evaluateToolCall", () => {
+  it("allows when the engine returns allow", async () => {
+    const { pipeline } = makePipeline(() => ALLOW);
+    const d = await pipeline.evaluateToolCall("exec", { command: "ls" }, CTX);
+    expect(d.allowed).toBe(true);
+  });
+
+  it("blocks when the engine returns block", async () => {
+    const { pipeline } = makePipeline(() => ({
+      action: "block",
+      event_id: "e",
+      reason: "dangerous",
+    }));
+    const d = await pipeline.evaluateToolCall("exec", { command: "rm -rf /" }, CTX);
+    expect(d.allowed).toBe(false);
+    expect(d.reason).toBe("dangerous");
+  });
+
+  it("appends triage reasoning to block reasons", async () => {
+    const { pipeline } = makePipeline(() => ({
+      action: "block",
+      event_id: "e",
+      reason: "blocked",
+      triage_results: [
+        {
+          verdict: "block",
+          confidence: 0.9,
+          reasoning: "rm of root",
+          suggested_action: "stop",
+          provider: "openai",
+          model: "gpt",
+          processing_time: 1,
+        },
+      ],
+    }));
+    const d = await pipeline.evaluateToolCall("exec", { command: "rm -rf /" }, CTX);
+    expect(d.reason).toBe("blocked (Triage: rm of root)");
+  });
+
+  it("fails closed (blocks) on require_approval", async () => {
+    const { pipeline } = makePipeline(() => ({
+      action: "require_approval",
+      event_id: "e",
+      overridable: true,
+    }));
+    const d = await pipeline.evaluateToolCall("exec", { command: "sudo x" }, CTX);
+    expect(d.allowed).toBe(false);
+    expect(d.overridable).toBe(true);
+  });
+
+  it("allows on the log action", async () => {
+    const { pipeline } = makePipeline(() => ({
+      action: "log",
+      event_id: "e",
+      alerts: [
+        {
+          rule_id: "r",
+          rule_name: "n",
+          severity: "low",
+          description: "d",
+          matched: true,
+          matched_fields: {},
+        },
+      ],
+    }));
+    const d = await pipeline.evaluateToolCall("exec", { command: "ls" }, CTX);
+    expect(d.allowed).toBe(true);
+  });
+
+  it("skips tools in the skip set without evaluating", async () => {
+    const evaluate = vi.fn(() => ALLOW);
+    const { pipeline } = makePipeline(evaluate, baseConfig({ skip: ["todo"] }));
+    const d = await pipeline.evaluateToolCall("todo", {}, CTX);
+    expect(d.allowed).toBe(true);
+    expect(evaluate).not.toHaveBeenCalled();
+  });
+
+  it("skips tools whose canonical name is in the skip set", async () => {
+    const evaluate = vi.fn(() => ALLOW);
+    const { pipeline } = makePipeline(evaluate, baseConfig({ skip: ["planning"] }));
+    const d = await pipeline.evaluateToolCall("task_plan", {}, CTX);
+    expect(d.allowed).toBe(true);
+    expect(evaluate).not.toHaveBeenCalled();
+  });
+
+  it("allows non-intercepted tools without evaluating when intercept is set", async () => {
+    const evaluate = vi.fn(() => ALLOW);
+    const { pipeline } = makePipeline(evaluate, baseConfig({ intercept: ["exec"] }));
+    const d = await pipeline.evaluateToolCall("read_file", { path: "/x" }, CTX);
+    expect(d.allowed).toBe(true);
+    expect(evaluate).not.toHaveBeenCalled();
+  });
+
+  it("evaluates intercepted tools matched by canonical name", async () => {
+    const evaluate = vi.fn(() => ALLOW);
+    const { pipeline } = makePipeline(evaluate, baseConfig({ intercept: ["read"] }));
+    await pipeline.evaluateToolCall("read_file", { path: "/x" }, CTX);
+    expect(evaluate).toHaveBeenCalledOnce();
+  });
+
+  it("fails closed by default when evaluation throws", async () => {
+    const { pipeline } = makePipeline(() => {
+      throw new Error("network down");
+    });
+    const d = await pipeline.evaluateToolCall("exec", { command: "ls" }, CTX);
+    expect(d.allowed).toBe(false);
+    expect(d.reason).toContain("fail-closed");
+  });
+
+  it("fails open when timeout_policy is allow", async () => {
+    const { pipeline } = makePipeline(
+      () => {
+        throw new Error("network down");
+      },
+      baseConfig({ timeout_policy: "allow" }),
+    );
+    const d = await pipeline.evaluateToolCall("exec", { command: "ls" }, CTX);
+    expect(d.allowed).toBe(true);
+  });
+
+  it("opens the circuit breaker and blocks after the failure threshold", async () => {
+    const { pipeline } = makePipeline(
+      () => {
+        throw new Error("down");
+      },
+      baseConfig({ timeout_policy: "block", circuit_breaker: { failure_threshold: 1, recovery_interval_ms: 30_000 } }),
+    );
+    // First call fails and opens the breaker.
+    await pipeline.evaluateToolCall("exec", { command: "ls" }, CTX);
+    // Second call should short-circuit via the breaker (still blocked).
+    const d = await pipeline.evaluateToolCall("exec", { command: "ls" }, CTX);
+    expect(d.allowed).toBe(false);
+  });
+});
+
+describe("GatewayPipeline.recordResult", () => {
+  it("sends a fire-and-forget audit report", () => {
+    const { pipeline, sendAudit } = makePipeline(() => ALLOW);
+    pipeline.recordResult("exec", { command: "ls" }, CTX, "out", {
+      isError: false,
+      errorMessage: null,
+      durationMs: 5,
+    });
+    expect(sendAudit).toHaveBeenCalledOnce();
+    const report = sendAudit.mock.calls[0]?.[0];
+    expect(report.event_type).toBe("tool_result");
+    expect(report.tool_name).toBe("exec");
+  });
+});

--- a/plugins/mcp-gateway/src/pipeline.ts
+++ b/plugins/mcp-gateway/src/pipeline.ts
@@ -1,0 +1,326 @@
+import { randomUUID } from "node:crypto";
+
+import { CircuitBreaker } from "./circuit-breaker.js";
+import { AgentShieldClient } from "./client.js";
+import {
+  buildAuditReport,
+  buildEvaluationRequest,
+  buildLifecycleEvent,
+  type ToolContext,
+} from "./event-builder.js";
+import { normaliseToolCall } from "./normalise.js";
+import type { AgentShieldConfig, EvaluationResponse, Logger } from "./types.js";
+
+const SEVERITY_ORDER: Record<string, number> = {
+  low: 0,
+  medium: 1,
+  high: 2,
+  critical: 3,
+};
+
+const NOTIFY_THRESHOLD: Record<string, number> = {
+  all: 0,
+  high: 2,
+  critical: 3,
+  none: 999,
+};
+
+const CORRELATION_TTL_MS = 60_000;
+
+/**
+ * The outcome of evaluating a tool call.
+ *
+ * - `allowed: true`  -> forward the call to the downstream MCP server.
+ * - `allowed: false` -> block; `reason` is surfaced to the agent.
+ * `overridable` flags a require_approval verdict so a host that supports an
+ * approval prompt can offer one; the gateway itself fails closed.
+ */
+export type Decision = {
+  allowed: boolean;
+  reason: string | null;
+  overridable: boolean;
+  eventId: string;
+};
+
+/**
+ * Thread-unsafe-but-single-threaded FIFO correlation tracker.
+ *
+ * Maps `(session, tool)` to a queue of evaluate `event_id`s so the post-call
+ * audit can link back to the pre-call evaluation (contract Section 1.2). Node
+ * runs this proxy on a single thread, so no lock is needed; stale entries are
+ * purged lazily on pop.
+ */
+class CorrelationTracker {
+  private readonly pending = new Map<string, Array<{ id: string; t: number }>>();
+
+  private static key(sessionId: string | null, tool: string): string {
+    return `${sessionId ?? ""}:${tool}`;
+  }
+
+  push(sessionId: string | null, tool: string, eventId: string): void {
+    const key = CorrelationTracker.key(sessionId, tool);
+    const bucket = this.pending.get(key) ?? [];
+    bucket.push({ id: eventId, t: Date.now() });
+    this.pending.set(key, bucket);
+  }
+
+  pop(sessionId: string | null, tool: string): string | null {
+    const key = CorrelationTracker.key(sessionId, tool);
+    const bucket = this.pending.get(key);
+    if (!bucket || bucket.length === 0) {
+      return null;
+    }
+    const now = Date.now();
+    while (bucket.length > 0 && now - (bucket[0] as { t: number }).t > CORRELATION_TTL_MS) {
+      bucket.shift();
+    }
+    if (bucket.length === 0) {
+      this.pending.delete(key);
+      return null;
+    }
+    const entry = bucket.shift() as { id: string };
+    if (bucket.length === 0) {
+      this.pending.delete(key);
+    }
+    return entry.id;
+  }
+}
+
+/**
+ * The security pipeline: skip -> intercept -> circuit-breaker -> evaluate ->
+ * act -> audit -> lifecycle (contract Section 3). MCP-transport-agnostic so it
+ * can be unit-tested with a stubbed client.
+ */
+export class GatewayPipeline {
+  private readonly config: AgentShieldConfig;
+  private readonly client: AgentShieldClient;
+  private readonly breaker: CircuitBreaker;
+  private readonly logger: Logger;
+  private readonly skipSet: Set<string>;
+  private readonly interceptSet: Set<string> | null;
+  private readonly correlation = new CorrelationTracker();
+
+  constructor(config: AgentShieldConfig, client: AgentShieldClient, logger: Logger) {
+    this.config = config;
+    this.client = client;
+    this.logger = logger;
+    this.breaker = new CircuitBreaker({
+      failureThreshold: config.circuit_breaker.failure_threshold,
+      recoveryIntervalMs: config.circuit_breaker.recovery_interval_ms,
+    });
+    this.skipSet = new Set(config.skip);
+    this.interceptSet = config.intercept.length > 0 ? new Set(config.intercept) : null;
+  }
+
+  /**
+   * Evaluate a single tool call before it reaches the downstream server.
+   *
+   * Returns a {@link Decision}. The original (possibly namespaced) tool name is
+   * passed through; normalisation happens internally so Sigma rules match.
+   */
+  async evaluateToolCall(
+    toolName: string,
+    args: Record<string, unknown>,
+    ctx: ToolContext,
+  ): Promise<Decision> {
+    const safeArgs = args && typeof args === "object" ? args : {};
+    const { canonical } = normaliseToolCall(toolName, safeArgs);
+
+    // Step 2: skip check (original or canonical name).
+    if (this.skipSet.has(toolName) || this.skipSet.has(canonical)) {
+      return this.allow(null);
+    }
+
+    // Step 3: intercept filter (only listed tools are evaluated).
+    if (
+      this.interceptSet &&
+      !this.interceptSet.has(toolName) &&
+      !this.interceptSet.has(canonical)
+    ) {
+      return this.allow(null);
+    }
+
+    // Step 4: circuit-breaker gate.
+    if (this.breaker.isOpen()) {
+      this.logger.warn(
+        `AgentShield circuit breaker open; applying ${this.config.timeout_policy} policy`,
+      );
+      return this.applyTimeoutPolicy();
+    }
+
+    // Step 5: build request.
+    const request = buildEvaluationRequest({ toolName, params: safeArgs }, ctx);
+
+    // Step 6: evaluate (awaited, timeout-bounded).
+    let response: EvaluationResponse;
+    try {
+      response = await this.client.evaluate(request);
+      this.breaker.recordSuccess();
+    } catch (err: unknown) {
+      this.breaker.recordFailure();
+      this.logger.warn(`AgentShield evaluation failed: ${String(err)}`);
+      return this.applyTimeoutPolicy();
+    }
+
+    // Step 7: act on the action.
+    return this.act(response, toolName, request.event_id, ctx);
+  }
+
+  /** Send a fire-and-forget audit report after the downstream tool runs. */
+  recordResult(
+    toolName: string,
+    args: Record<string, unknown>,
+    ctx: ToolContext,
+    result: unknown,
+    opts: { isError: boolean; errorMessage: string | null; durationMs: number },
+  ): void {
+    const safeArgs = args && typeof args === "object" ? args : {};
+    const corrId = this.correlation.pop(ctx.sessionId, toolName) ?? randomUUID();
+    const report = buildAuditReport(
+      {
+        toolName,
+        params: safeArgs,
+        result,
+        isError: opts.isError,
+        error: opts.errorMessage ?? undefined,
+        durationMs: opts.durationMs,
+      },
+      ctx,
+      corrId,
+    );
+    this.client.sendAudit(report);
+  }
+
+  /** Emit a fire-and-forget lifecycle event (session_start / session_end). */
+  recordLifecycle(eventType: "session_start" | "session_end", ctx: ToolContext): void {
+    this.client.sendLifecycle(buildLifecycleEvent(eventType, ctx));
+  }
+
+  /** Report a user override of a block / require_approval verdict (Section 1.5). */
+  reportOverride(sessionId: string, eventId: string): void {
+    this.client.sendOverride(sessionId, eventId);
+  }
+
+  /** Non-blocking startup health probe. */
+  async startupHealthCheck(): Promise<void> {
+    try {
+      const ok = await this.client.healthCheck();
+      if (ok) {
+        this.logger.info(`AgentShield reachable at ${this.config.endpoint}`);
+      } else {
+        this.logger.warn(
+          `AgentShield not reachable at ${this.config.endpoint} (will retry on first tool call)`,
+        );
+      }
+    } catch {
+      this.logger.warn("AgentShield health check failed");
+    }
+  }
+
+  private act(
+    response: EvaluationResponse,
+    toolName: string,
+    eventId: string,
+    ctx: ToolContext,
+  ): Decision {
+    if (response.effective_mode) {
+      this.logger.debug(`AgentShield effective mode for ${toolName}: ${response.effective_mode}`);
+    }
+    for (const triage of response.triage_results ?? []) {
+      this.logger.info(
+        `AgentShield triage: ${triage.verdict} (${triage.confidence}) - ${triage.reasoning}`,
+      );
+    }
+
+    const action = response.action;
+
+    if (action === "block") {
+      const triageReason = response.triage_results?.[0]?.reasoning;
+      let reason = response.reason || "Blocked by AgentShield";
+      if (triageReason) {
+        reason = `${reason} (Triage: ${triageReason})`;
+      }
+      this.logger.warn(`AgentShield blocked ${toolName}: ${reason}`);
+      this.maybeNotify(response, toolName, "blocked");
+      return { allowed: false, reason, overridable: false, eventId };
+    }
+
+    if (action === "require_approval") {
+      // Fail-closed: MCP has no synchronous user-approval channel, so we block
+      // (contract Section 3.2). overridable=true lets a host offer an override.
+      const reason =
+        response.reason ||
+        "AgentShield requires explicit approval before this tool call can proceed";
+      this.logger.warn(`AgentShield requires approval for ${toolName}: ${reason}`);
+      this.maybeNotify(response, toolName, "requires approval");
+      return { allowed: false, reason, overridable: response.overridable ?? true, eventId };
+    }
+
+    // High-confidence allow override: alerts present but triage says allow.
+    const hasHcAllow = (response.triage_results ?? []).some(
+      (t) => t.verdict === "allow" && (t.confidence ?? 0) > 0.8,
+    );
+    if (response.alerts && response.alerts.length > 0 && hasHcAllow) {
+      this.logger.info(
+        `AgentShield: ${response.alerts.length} alert(s) for ${toolName}, overridden by high-confidence allow`,
+      );
+    } else if (action === "log" && response.alerts && response.alerts.length > 0) {
+      this.logger.info(
+        `AgentShield logged ${response.alerts.length} alert(s) for ${toolName}`,
+      );
+      this.maybeNotify(response, toolName, "logged");
+    }
+
+    // allow / log -> push correlation for audit linkage and permit.
+    this.correlation.push(ctx.sessionId, toolName, eventId);
+    return { allowed: true, reason: null, overridable: false, eventId };
+  }
+
+  private allow(reason: string | null): Decision {
+    return { allowed: true, reason, overridable: false, eventId: randomUUID() };
+  }
+
+  private applyTimeoutPolicy(): Decision {
+    if (this.config.timeout_policy === "block") {
+      return {
+        allowed: false,
+        reason: "AgentShield unavailable (fail-closed policy)",
+        overridable: false,
+        eventId: randomUUID(),
+      };
+    }
+    // allow / log -> fail open.
+    return this.allow(null);
+  }
+
+  private maybeNotify(
+    response: EvaluationResponse,
+    toolName: string,
+    action: string,
+  ): void {
+    const alerts = response.alerts ?? [];
+    if (alerts.length === 0) {
+      return;
+    }
+    const threshold = NOTIFY_THRESHOLD[this.config.notify] ?? 2;
+    const meets = alerts.some(
+      (a) => (SEVERITY_ORDER[a.severity] ?? 0) >= threshold,
+    );
+    if (!meets) {
+      return;
+    }
+    const top = alerts[0];
+    if (!top) {
+      return;
+    }
+    const parts = [
+      `AgentShield Alert - ${action} (${top.severity})`,
+      `Rule: ${top.rule_name}`,
+      `Tool: ${toolName}`,
+    ];
+    if (alerts.length > 1) {
+      parts.push(`(+${alerts.length - 1} more alert${alerts.length > 2 ? "s" : ""})`);
+    }
+    this.logger.warn(parts.join(" | "));
+  }
+}

--- a/plugins/mcp-gateway/src/types.ts
+++ b/plugins/mcp-gateway/src/types.ts
@@ -1,0 +1,149 @@
+/**
+ * Shared types for the AgentShield MCP gateway.
+ *
+ * Wire payloads (EvaluationRequest/Response, AuditReport, LifecycleEvent,
+ * OverrideRequest) mirror the AgentShield Connector Contract v1.0.0 exactly so
+ * that the same Sigma rules apply across every connector. The `source` field is
+ * hard-coded to "mcp-gateway".
+ */
+
+/** Downstream MCP server transport selection. */
+export type DownstreamTransport = "stdio" | "http";
+
+/** Configuration for the downstream MCP server this gateway proxies to. */
+export type DownstreamConfig = {
+  /** Transport used to reach the downstream server. */
+  transport: DownstreamTransport;
+  /** Launch command for a stdio downstream server (required when transport=stdio). */
+  command: string | null;
+  /** Arguments for the stdio launch command. */
+  args: string[];
+  /** Extra environment variables passed to the stdio child process. */
+  env: Record<string, string>;
+  /** Base URL for an HTTP/SSE downstream server (required when transport=http). */
+  url: string | null;
+};
+
+/** How the gateway itself exposes the proxied server to the agent. */
+export type ServeConfig = {
+  /** Transport the gateway listens on for the upstream agent. */
+  transport: DownstreamTransport;
+  /** Port for HTTP serving (ignored for stdio). */
+  port: number;
+  /** Host for HTTP serving (ignored for stdio). */
+  host: string;
+};
+
+/** Plugin configuration parsed from env + JSON file (contract Section 4). */
+export type AgentShieldConfig = {
+  enabled: boolean;
+  endpoint: string;
+  auth_token: string;
+  timeout_ms: number;
+  timeout_policy: "allow" | "block" | "log";
+  intercept: string[];
+  skip: string[];
+  notify: "all" | "high" | "critical" | "none";
+  circuit_breaker: {
+    failure_threshold: number;
+    recovery_interval_ms: number;
+  };
+  downstream: DownstreamConfig;
+  serve: ServeConfig;
+};
+
+/** Evaluation request payload (contract Section 1.1). */
+export type EvaluationRequest = {
+  event_id: string;
+  timestamp: string;
+  event_type: string;
+  tool_name: string;
+  source: "mcp-gateway";
+  command: string | null;
+  params: Record<string, unknown>;
+  agent_id: string | null;
+  session_id: string | null;
+  working_dir: string | null;
+  data: Record<string, unknown>;
+};
+
+/** Triage result from LLM analysis. */
+export type TriageResult = {
+  verdict: "block" | "allow" | "investigate";
+  confidence: number;
+  reasoning: string;
+  suggested_action: string;
+  provider: string;
+  model: string;
+  processing_time: number;
+};
+
+/** Alert from the detection engine. */
+export type Alert = {
+  rule_id: string;
+  rule_name: string;
+  severity: "low" | "medium" | "high" | "critical";
+  description: string;
+  matched: boolean;
+  matched_fields: Record<string, unknown>;
+};
+
+/** Evaluation response payload (contract Section 1.1). */
+export type EvaluationResponse = {
+  action: "allow" | "block" | "log" | "require_approval";
+  event_id: string;
+  alerts?: Array<Alert>;
+  reason?: string;
+  triage_results?: Array<TriageResult>;
+  overridable?: boolean;
+  effective_mode?: "enforce" | "audit" | "shadow";
+  cached?: boolean;
+  feedback_url?: string;
+  timestamp?: string;
+};
+
+/** Audit report payload (contract Section 1.2). */
+export type AuditReport = {
+  event_id: string;
+  correlation_id: string;
+  timestamp: string;
+  event_type: "tool_result";
+  tool_name: string;
+  source: "mcp-gateway";
+  result_summary: string | null;
+  is_error: boolean;
+  error_message: string | null;
+  duration_ms: number;
+  agent_id: string | null;
+  session_id: string | null;
+  working_dir: string | null;
+  data: Record<string, unknown>;
+};
+
+/** Lifecycle event payload (contract Section 1.3). */
+export type LifecycleEvent = {
+  event_id: string;
+  timestamp: string;
+  event_type: string;
+  source: "mcp-gateway";
+  agent_id: string | null;
+  session_id: string | null;
+  data: Record<string, unknown>;
+};
+
+/** Override request payload (contract Section 1.5). */
+export type OverrideRequest = {
+  session_id: string;
+  event_id: string;
+};
+
+/** Circuit breaker states. */
+export type CircuitBreakerState = "closed" | "open" | "half-open";
+
+/** Minimal logger interface. Writes go to stderr to keep stdout clean for stdio MCP. */
+export type Logger = {
+  debug: (message: string) => void;
+  info: (message: string) => void;
+  warn: (message: string) => void;
+  error: (message: string) => void;
+};

--- a/plugins/mcp-gateway/tsconfig.json
+++ b/plugins/mcp-gateway/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "vitest.config.ts"]
+}

--- a/plugins/mcp-gateway/vitest.config.ts
+++ b/plugins/mcp-gateway/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    exclude: ["**/node_modules/**", "**/dist/**"],
+  },
+});


### PR DESCRIPTION
## Overview
Adds a standalone **MCP (Model Context Protocol) security gateway** that proxies between an MCP client (the agent) and downstream MCP server(s). Every `tools/call` is normalised to the shared canonical vocabulary and evaluated via `POST /api/v1/evaluate` before being forwarded; `tools/list` and other methods pass through transparently.

This single component gives near-universal coverage across **every MCP-speaking agent** (Claude Code, Codex, Gemini CLI, Cursor, Windsurf), including closed platforms with no native hook API — so it doubles as the full-enforcement fallback for the hook-based connectors.

## What it does
- **TypeScript** with the official `@modelcontextprotocol/sdk`; **stdio** (primary) and **streamable HTTP** transports.
- Blocked and (fail-closed) `require_approval` verdicts are returned as an `isError` tool result carrying the engine's reason, so the model reads the reason rather than silently retrying.
- Same wire contract as the other connectors: evaluate, fire-and-forget audit, `initialize`/`shutdown` → `session_start`/`session_end` lifecycle, startup health probe.
- Three-state circuit breaker; layered config (defaults < JSON file < env); `AGENTSHIELD_AUTH_TOKEN` fallback; no hardcoded secrets.

## Tests
`tsc` clean (strict), 65 unit tests pass, plus an end-to-end stdio proxy smoke test (benign call forwarded, `/etc/passwd` read blocked).

## Notes
- Marked **In development** in `PLATFORMS.md` pending sign-off.
- Touches the `PLATFORMS.md` integrations table — expect a trivial one-row conflict with the sibling connector PRs (union-resolve).