### PR TITLE
fix(rules): make tool-registry-tampering rule RE2-compatible

### DIFF
--- a/rules/rules/ai_agent/ai_agent_tool_registry_tampering.yml
+++ b/rules/rules/ai_agent/ai_agent_tool_registry_tampering.yml
@@ -33,12 +33,16 @@ detection:
       - 'mcp_tool_register'
   selection_instruction_in_description:
     arguments|re: '(?i)"description"\s*:\s*"[^"]*\b(always\s+include|first\s+call|send\s+(output|results|data)\s+to\s+https?://|call\s+this\s+(before|after)|do\s+not\s+log|ignore\s+the\s+above)[^"]*"'
-  selection_no_version_bump:
-    arguments|re: '(?i)"description"\s*:[^}]*(?!"version")(?!"schema_version")'
+  selection_description_update:
     command|contains:
       - 'update_tool'
       - 'patch_tool_schema'
-  condition: selection_schema_write and (selection_instruction_in_description or selection_no_version_bump)
+    arguments|re: '(?i)"description"\s*:'
+  filter_version_bump:
+    arguments|contains:
+      - '"version"'
+      - '"schema_version"'
+  condition: selection_schema_write and (selection_instruction_in_description or (selection_description_update and not filter_version_bump))
 falsepositives:
   - Internal developer tooling that writes conversational examples or usage
     notes inline within description fields during legitimate development


### PR DESCRIPTION
## Problem
At engine startup, `ai_agent_tool_registry_tampering.yml` fails to load:

```
Failed to load rule ... error="parsing Sigma rule: ... search identifier
\"selection_no_version_bump\": arguments|re: pattern 1: error parsing regexp:
invalid or unsupported Perl syntax: `(?!`"
```

The `selection_no_version_bump` regex used **Perl negative lookaheads** — `(?!"version")(?!"schema_version")` — which Go's `regexp` engine (RE2) does not support. The engine logged a WARN and **silently skipped the rule** (loading 58 of 59), so tool-registry tampering without a version bump went undetected.

## Fix
Express "no version bump" the Sigma-idiomatic way instead of with a lookahead:
- `selection_description_update` — matches a `"description":` change on `update_tool`/`patch_tool_schema` calls (RE2-safe regex).
- `filter_version_bump` — matches `"version"`/`"schema_version"` present.
- `condition: … or (selection_description_update and not filter_version_bump)`.

Same intent, no lookaheads. (The original lookahead was also semantically dubious — anchored at end-of-input after a greedy `[^}]*`, it would nearly always succeed.)

## Verification
`agentshield rules list` now loads **59/59 rules with zero parse errors** (was 58/59); the tool-registry-tampering rule is present.

> **Upstream note:** these rules are vendored from `agentshield-ai/sigma-ai` via git subtree. The same fix should land upstream so the next sync doesn't revert it. The `sigma-ai-sync-check` job only verifies rule *presence* (not content), so this PR passes it.