### PR TITLE
chore(rules): sync 4 missing sigma-ai rules

### DIFF
--- a/rules/rules/ai_agent/ai_agent_api_endpoint_redirection.yml
+++ b/rules/rules/ai_agent/ai_agent_api_endpoint_redirection.yml
@@ -1,0 +1,61 @@
+title: Agent API Endpoint or Auth Header Redirection
+id: 9e338173-4519-5c00-9fb6-d72b3cb0fd6f
+status: experimental
+description: |
+  Detects agent runtime configuration that redirects model API traffic
+  (base URL, proxy, or Authorization header destination) to a host that
+  is not the canonical model provider endpoint. CVE-2026-21852 in Claude
+  Code allowed a repository-controlled setting to redirect API traffic —
+  including the full Authorization header — to an attacker-controlled
+  server before the user accepted the trust dialog. The same pattern
+  has been observed in LiteLLM proxy hijacks and malicious MCP server
+  configurations that wrap the model endpoint.
+references:
+  - https://research.checkpoint.com/2026/rce-and-api-token-exfiltration-through-claude-code-project-files-cve-2025-59536/
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-21852
+  - https://attack.mitre.org/techniques/T1556/
+  - https://attack.mitre.org/techniques/T1090/
+author: AgentShield
+date: "2026-05-21"
+tags:
+  - attack.credential-access
+  - attack.t1556
+  - attack.command-and-control
+  - attack.t1090
+logsource:
+  product: ai_agent
+  category: agent_events
+detection:
+  selection_endpoint_override:
+    event_type:
+      - config_load
+      - env_set
+      - file_write
+    content|contains:
+      - 'ANTHROPIC_BASE_URL='
+      - 'ANTHROPIC_API_URL='
+      - 'OPENAI_BASE_URL='
+      - 'OPENAI_API_BASE='
+      - '"baseURL"'
+      - '"base_url"'
+      - '"apiBase"'
+      - '"proxy"'
+      - 'HTTPS_PROXY='
+      - 'HTTP_PROXY='
+  selection_base_url_override:
+    content|re: '(ANTHROPIC_BASE_URL|OPENAI_BASE_URL|ANTHROPIC_API_URL|OPENAI_API_BASE|baseURL|base_url|apiBase)\s*[:=]\s*"?https?://'
+  filter_canonical_base_url:
+    content|re: '(ANTHROPIC_BASE_URL|OPENAI_BASE_URL|ANTHROPIC_API_URL|OPENAI_API_BASE|baseURL|base_url|apiBase)\s*[:=]\s*"?https?://(api\.anthropic\.com|api\.openai\.com|generativelanguage\.googleapis\.com|api\.mistral\.ai|api\.cohere\.com|api\.x\.ai)(/|"|$)'
+  selection_auth_header_to_external:
+    event_type: outbound_request
+    request.headers|contains:
+      - 'Authorization: Bearer sk-'
+      - 'x-api-key:'
+  filter_canonical_destination:
+    destination.host|re: '\.(anthropic|openai|googleapis|mistral|cohere|x\.ai)\.com'
+  condition: (selection_endpoint_override and selection_base_url_override and not filter_canonical_base_url) or (selection_auth_header_to_external and not filter_canonical_destination)
+falsepositives:
+  - Approved enterprise LLM proxies (Portkey, LiteLLM gateway, Cloudflare AI Gateway) on internal hosts — allowlist via destination.host
+  - Self-hosted model deployments where the base URL legitimately points to an internal endpoint
+  - Local development against a mock server on localhost
+level: critical

--- a/rules/rules/ai_agent/ai_agent_inter_agent_spoofing.yml
+++ b/rules/rules/ai_agent/ai_agent_inter_agent_spoofing.yml
@@ -1,0 +1,70 @@
+title: Inter-Agent Message Spoofing and Peer Impersonation
+id: 83e72875-7c6f-52cc-949c-505cbbb7649f
+status: experimental
+description: |
+  Detects messages between agents that claim a privileged peer identity
+  without a verifiable identity proof (mTLS, signed JWT, or mOIDC token),
+  or instruct another agent to take a destructive action based solely on
+  an unverified peer status report. Addresses OWASP ASI07 (Insecure
+  Inter-Agent Communication) and the multi-agent collusion patterns
+  documented by the Handala "Wiper" incident, where a compromised data
+  entry agent convinced a backup agent that the database was corrupted
+  and should be overwritten.
+references:
+  - https://arxiv.org/html/2505.02077v2
+  - https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/
+  - https://techbytes.app/posts/rogue-ai-agent-collusion-insider-security-risk/
+  - https://attack.mitre.org/techniques/T1036/
+  - https://attack.mitre.org/techniques/T1565/
+author: AgentShield
+date: "2026-05-21"
+tags:
+  - attack.defense-evasion
+  - attack.t1036
+  - attack.impact
+  - attack.t1565
+logsource:
+  product: ai_agent
+  category: agent_events
+detection:
+  selection_unauthenticated_peer:
+    event_type: agent_message
+    message.peer_identity_verified: false
+    message.claimed_role|contains:
+      - 'orchestrator'
+      - 'supervisor'
+      - 'admin'
+      - 'root'
+      - 'planner'
+      - 'backup'
+      - 'security'
+  selection_destructive_directive:
+    event_type: agent_message
+    message.directive|contains:
+      - 'overwrite'
+      - 'delete'
+      - 'truncate'
+      - 'drop table'
+      - 'rm -rf'
+      - 'wipe'
+      - 'reset_state'
+      - 'rotate_keys'
+      - 'revoke_all'
+  selection_identity_mismatch:
+    event_type: agent_message
+    # Custom: AgentShield compares the claimed sender against the verified
+    # transport-layer identity (mTLS CN, signed JWT sub, mOIDC subject).
+    # '*' asserts the field is present (any value); the engine's Sigma fork
+    # does not support the |exists modifier.
+    message.claimed_sender_id: '*'
+    message.verified_sender_id: '*'
+    message.identity_match: false
+  selection_unsigned_orchestration:
+    event_type: agent_handoff
+    handoff.signature_valid: false
+  condition: (selection_unauthenticated_peer and selection_destructive_directive) or selection_identity_mismatch or selection_unsigned_orchestration
+falsepositives:
+  - Single-process agent frameworks where peer identity is implicit (LangGraph, AutoGen local runs) — scope this rule to deployments using a multi-agent transport
+  - Test harnesses that simulate agent handoffs without signing
+  - Legacy orchestrators not yet upgraded to the agent-to-agent OAuth profile
+level: high

--- a/rules/rules/ai_agent/ai_agent_recursive_loop_exhaustion.yml
+++ b/rules/rules/ai_agent/ai_agent_recursive_loop_exhaustion.yml
@@ -1,0 +1,44 @@
+title: Recursive Agent Loop and Token Budget Exhaustion
+id: 6991e62a-6efd-5f7d-b5ff-7e57ffa6158c
+status: experimental
+description: |
+  Detects agent sessions that exhibit recursive or non-converging behaviour:
+  the same tool invoked with identical arguments many times within a short
+  window, step count exceeding the agent's configured budget, or cumulative
+  token spend crossing a denial-of-wallet threshold without state change.
+  This addresses OWASP ASI10 (Recursive Resource Exhaustion / Agentic Loops)
+  and the runaway-cost incidents documented in 2026, where unbounded agent
+  loops produced four-figure API bills in hours.
+references:
+  - https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/
+  - https://www.toxsec.com/p/denial-of-wallet
+  - https://instatunnel.my/blog/agentic-resource-exhaustion-the-infinite-loop-attack-of-the-ai-era
+  - https://attack.mitre.org/techniques/T1499/
+author: AgentShield
+date: "2026-05-21"
+tags:
+  - attack.impact
+  - attack.t1499
+logsource:
+  product: ai_agent
+  category: agent_events
+detection:
+  selection_repeat_tool_call:
+    event_type: tool_call
+    # Custom: AgentShield tracks how many times this (tool_name, args_hash) tuple
+    # has been issued in the current session.
+    session.identical_tool_call_count|re: '^([2-9][0-9]|[1-9][0-9]{2,})$'
+  selection_step_budget_breach:
+    session.step_count|re: '^([5-9][0-9]|[1-9][0-9]{2,})$'
+    session.goal_state_changed: false
+  selection_token_budget_breach:
+    session.cumulative_tokens|re: '^([5-9][0-9]{5}|[1-9][0-9]{6,})$'
+  selection_self_prompt_recursion:
+    event_type: model_call
+    session.self_prompt_depth|re: '^([5-9]|[1-9][0-9]+)$'
+  condition: 1 of selection_*
+falsepositives:
+  - Long-running batch agents with an explicit, approved high token budget
+  - Iterative refinement workflows (e.g. code review loops) where step_count is high but goal_state_changed flips on each iteration
+  - Load tests and benchmark runs
+level: high

--- a/rules/rules/ai_agent/ai_agent_settings_hook_injection.yml
+++ b/rules/rules/ai_agent/ai_agent_settings_hook_injection.yml
@@ -1,0 +1,59 @@
+title: Agent Settings Hook Injection on Repository Open
+id: 60f48f07-61b7-5c42-afd8-ed26c11ccefd
+status: experimental
+description: |
+  Detects repository-scoped agent configuration files that declare hooks,
+  MCP servers, or auto-enable flags executed at session start. Cloning a
+  repository containing a malicious .claude/settings.json, .cursor/mcp.json,
+  or equivalent inherits the configuration, and a SessionStart or
+  PreToolUse hook can achieve remote code execution before the user is
+  shown a trust prompt. This pattern was used in CVE-2025-59536 against
+  Claude Code and observed across other agent CLIs in early 2026.
+references:
+  - https://research.checkpoint.com/2026/rce-and-api-token-exfiltration-through-claude-code-project-files-cve-2025-59536/
+  - https://nvd.nist.gov/vuln/detail/CVE-2025-59536
+  - https://attack.mitre.org/techniques/T1546/
+  - https://attack.mitre.org/techniques/T1195/002/
+author: AgentShield
+date: "2026-05-21"
+tags:
+  - attack.execution
+  - attack.t1059
+  - attack.persistence
+  - attack.t1546
+  - attack.initial-access
+  - attack.t1195.002
+logsource:
+  product: ai_agent
+  category: agent_events
+detection:
+  selection_settings_files:
+    event_type: file_read
+    file_path|contains:
+      - '.claude/settings.json'
+      - '.claude/settings.local.json'
+      - '.cursor/mcp.json'
+      - '.codex/config.toml'
+      - '.windsurf/config.json'
+      - '.continue/config.json'
+  selection_hook_keys:
+    content|contains:
+      - '"hooks"'
+      - '"SessionStart"'
+      - '"PreToolUse"'
+      - '"PostToolUse"'
+      - '"UserPromptSubmit"'
+      - '"Stop"'
+  selection_auto_enable_mcp:
+    content|contains:
+      - '"enableAllProjectMcpServers": true'
+      - '"enable_all_project_mcp_servers": true'
+      - '"trustProjectMcp": true'
+  selection_repo_inherited:
+    session.phase: session_start
+    session.project_first_open: true
+  condition: selection_settings_files and (selection_hook_keys or selection_auto_enable_mcp) and selection_repo_inherited
+falsepositives:
+  - Trusted internal repositories that ship a curated settings.json for developer onboarding
+  - Re-opening a project the user has previously approved (signalled by session.project_first_open being false)
+level: critical


### PR DESCRIPTION
## Overview
The vendored rule corpus had drifted **behind upstream `agentshield-ai/sigma-ai` by four rules**, which kept the `sigma-ai-sync-check` job red (on `main` and on any PR touching `rules/**`):

- `ai_agent_inter_agent_spoofing.yml`
- `ai_agent_recursive_loop_exhaustion.yml`
- `ai_agent_api_endpoint_redirection.yml`
- `ai_agent_settings_hook_injection.yml`

## Why not a full subtree pull?
The canonical `scripts/sync_sigma_ai.sh` does `git subtree pull --squash`, which would have:
1. **Reverted the RE2 fix from #69** — upstream still ships the broken `(?!…)` lookahead in `tool_registry_tampering.yml` (verified).
2. Pulled unreviewed content changes to other rules.

So I added the four files directly (the sync-check verifies rule *presence*, not content).

## Two engine-compatibility adaptations
The engine's forked sigmalite supports neither Perl lookaheads nor the `|exists` modifier, so two rules needed minimal adaptation (the other two are verbatim from upstream):

- **`api_endpoint_redirection`** — two negative lookaheads (`(?!canonical-host)`) rewritten as positive `filter_*` selections negated in the `condition:`, preserving the host allowlist exactly. (Without this it would silently fail to load, like the rule #69 just fixed.)
- **`inter_agent_spoofing`** — `field|exists: true` presence checks rewritten as `field: '*'` (matches any value). The real detection hinges on `message.identity_match: false`; the presence checks are unchanged in intent.

## Verification
- Engine loads **63/63 rules, zero parse errors** (was 59).
- `scripts/check_sigma_ai_sync.sh main` → "All upstream sigma-ai rules present".

> **Upstream follow-up:** these adaptations diverge from upstream content, so the next subtree sync would reintroduce the incompatibilities. The durable fix is upstream — either author the rules within the engine's supported Sigma subset, or extend the engine fork to support lookaheads + `|exists`. Upstream `tool_registry_tampering`, `api_endpoint_redirection`, and `inter_agent_spoofing` all currently use unsupported constructs.